### PR TITLE
fix: `ModalHandler` not awaiting modal run

### DIFF
--- a/.changeset/popular-doors-sneeze.md
+++ b/.changeset/popular-doors-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@buape/carbon": patch
+---
+
+fix: `ModalHandler` not awaiting modal run

--- a/packages/carbon/src/internals/ModalHandler.ts
+++ b/packages/carbon/src/internals/ModalHandler.ts
@@ -22,6 +22,6 @@ export class ModalHandler extends Base {
 		const modal = this.modals.find((x) => x.customId === data.data.custom_id)
 		if (!modal) return false
 
-		modal.run(new ModalInteraction(this.client, data, {}))
+		return await modal.run(new ModalInteraction(this.client, data, {}))
 	}
 }


### PR DESCRIPTION
Without awaiting the modal, Vercel function exits before it has a chance to reply. I `pnpm patch`ed Carbon with this change for my bot and it fixed it.