### PR TITLE
Fixes README.md getting started URL

### DIFF
--- a/packages/carbon/README.md
+++ b/packages/carbon/README.md
@@ -29,7 +29,7 @@ To get started with Carbon, you can check out the [Getting Started](https://carb
 
 ## Useful Links
 
-- [Documentation](https://carbon.buape.com/docs)
+- [Documentation](https://carbon.buape.com/carbon)
 - [Discord](https://go.buape.com/carbon)
 - [NPM](https://www.npmjs.com/package/@buape/carbon)
 - [Cloudflare Workers Demo](https://github.com/buape/carbon/tree/main/apps/cloudo)
@@ -37,4 +37,4 @@ To get started with Carbon, you can check out the [Getting Started](https://carb
 
 ## Contributing
 
-We welcome contributions to Carbon! If you're interested in contributing, please check out the [Contributing Guide](https://carbon.buape.com/docs/helpful-guides/contributing) for more information, and join our [Discord](https://go.buape.com/carbon) to get involved!
+We welcome contributions to Carbon! If you're interested in contributing, please check out the [Contributing Guide](https://carbon.buape.com/carbon/helpful-guides/contributing) for more information, and join our [Discord](https://go.buape.com/carbon) to get involved!

--- a/packages/carbon/README.md
+++ b/packages/carbon/README.md
@@ -25,7 +25,7 @@ With Carbon, you can deploy it to many platforms, both physical and serverless, 
 
 ## Installation
 
-To get started with Carbon, you can check out the [Getting Started](https://carbon.buape.com/docs/getting-started) guides for your preferred platform.
+To get started with Carbon, you can check out the [Getting Started](https://carbon.buape.com/carbon/getting-started) guides for your preferred platform.
 
 ## Useful Links
 


### PR DESCRIPTION
Changes the installation tab to go to [/carbon](https://carbon.buape.com/carbon/getting-started) instead of [/docs](https://carbon.buape.com/docs/getting-started)