### PR TITLE
Fix doc links in the README.md files

### DIFF
--- a/packages/carbon/README.md
+++ b/packages/carbon/README.md
@@ -25,11 +25,11 @@ With Carbon, you can deploy it to many platforms, both physical and serverless, 
 
 ## Installation
 
-To get started with Carbon, you can check out the [Getting Started](https://carbon.buape.com/docs/getting-started) guides for your preferred platform.
+To get started with Carbon, you can check out the [Getting Started](https://carbon.buape.com/carbon/getting-started) guides for your preferred platform.
 
 ## Useful Links
 
-- [Documentation](https://carbon.buape.com/docs)
+- [Documentation](https://carbon.buape.com/carbon)
 - [Discord](https://go.buape.com/carbon)
 - [NPM](https://www.npmjs.com/package/@buape/carbon)
 - [Cloudflare Workers Demo](https://github.com/buape/carbon/tree/main/apps/cloudo)
@@ -37,4 +37,4 @@ To get started with Carbon, you can check out the [Getting Started](https://carb
 
 ## Contributing
 
-We welcome contributions to Carbon! If you're interested in contributing, please check out the [Contributing Guide](https://carbon.buape.com/docs/helpful-guides/contributing) for more information, and join our [Discord](https://go.buape.com/carbon) to get involved!
+We welcome contributions to Carbon! If you're interested in contributing, please check out the [Contributing Guide](https://carbon.buape.com/carbon/helpful-guides/contributing) for more information, and join our [Discord](https://go.buape.com/carbon) to get involved!

--- a/packages/create-carbon/README.md
+++ b/packages/create-carbon/README.md
@@ -24,4 +24,4 @@ This will create a new directory called `my-project` with a basic Carbon project
 
 ## Contributing
 
-We welcome contributions to `create-carbon`! If you're interested in contributing, please check out the [Contributing Guide](https://carbon.buape.com/docs/helpful-guides/contributing) for more information, and join our [Discord](https://go.buape.com/carbon) to get involved!
+We welcome contributions to `create-carbon`! If you're interested in contributing, please check out the [Contributing Guide](https://carbon.buape.com/carbon/helpful-guides/contributing) for more information, and join our [Discord](https://go.buape.com/carbon) to get involved!

--- a/packages/linked-roles/README.md
+++ b/packages/linked-roles/README.md
@@ -10,4 +10,4 @@
 
 This package is part of [the Carbon framework](https://github.com/buape/carbon), check it out for more details.
 
-You can find the documentation for this package [here](https://carbon.buape.com/docs/linked-roles).
+You can find the documentation for this package [here](https://carbon.buape.com/carbon/linked-roles).

--- a/packages/nodejs/README.md
+++ b/packages/nodejs/README.md
@@ -10,4 +10,4 @@
 
 This package is part of [the Carbon framework](https://github.com/buape/carbon), check it out for more details.
 
-You can find the documentation for this package [here](https://carbon.buape.com/docs/nodejs).
+You can find the documentation for this package [here](https://carbon.buape.com/carbon/nodejs).

--- a/packages/request/README.md
+++ b/packages/request/README.md
@@ -10,4 +10,4 @@
 
 This package is part of [the Carbon framework](https://github.com/buape/carbon), check it out for more details.
 
-You can find the documentation for this package [here](https://carbon.buape.com/docs/request).
+You can find the documentation for this package [here](https://carbon.buape.com/carbon/request).


### PR DESCRIPTION
Changes the docs URL to go to [/carbon](https://carbon.buape.com/carbon) instead of [/docs](https://carbon.buape.com/docs)