### PR TITLE
Fixes modes.ts URL

### DIFF
--- a/website/modes.ts
+++ b/website/modes.ts
@@ -15,7 +15,7 @@ export interface Mode {
 
 export const modes: Mode[] = [
 	{
-		param: "docs",
+		param: "carbon",
 		name: "Carbon",
 		description: "@buape/carbon",
 		icon: Package


### PR DESCRIPTION
Fixes the @buape/carbon url, makes it actually work
![image](https://github.com/user-attachments/assets/5e09dfe4-ab7c-4f17-b20f-853e5b5644db)
