### PR TITLE
Fix layout.config.tsx URLs

### DIFF
--- a/website/app/layout.config.tsx
+++ b/website/app/layout.config.tsx
@@ -7,7 +7,7 @@ import { utils } from "~/app/source"
 import { modes } from "~/modes"
 
 export const baseOptions: HomeLayoutProps = {
-	githubUrl: "https://github.com/fuma-nama/fumadocs",
+	githubUrl: "https://github.com/buape/carbon",
 	nav: {
 		enableSearch: true,
 		title: (
@@ -36,7 +36,7 @@ export const baseOptions: HomeLayoutProps = {
 		},
 		{
 			text: "Showcase",
-			url: "/showcase",
+			url: "/carbon/even-more/powered-by-carbon",
 			icon: <LayoutTemplateIcon />
 		},
 		{

--- a/website/app/layout.config.tsx
+++ b/website/app/layout.config.tsx
@@ -29,19 +29,13 @@ export const baseOptions: HomeLayoutProps = {
 	},
 	links: [
 		{
-			icon: <BookIcon />,
-			text: "Blog",
-			url: "/blog",
-			active: "nested-url"
-		},
-		{
 			text: "Showcase",
 			url: "/carbon/even-more/powered-by-carbon",
 			icon: <LayoutTemplateIcon />
 		},
 		{
 			text: "Sponsors",
-			url: "/sponsors",
+			url: "https://github.com/sponsors/buape",
 			icon: <Heart />
 		}
 	]


### PR DESCRIPTION
Fixes showcase and github in the dropdown menu, sponsors and blog are still missing cus idk what should go there.
![image](https://github.com/user-attachments/assets/d2fd6160-be97-44b7-ae9e-e37e87330391)
