### PR TITLE
Fix developer portal button

### DIFF
--- a/website/content/carbon/getting-started/cloudflare-workers.mdx
+++ b/website/content/carbon/getting-started/cloudflare-workers.mdx
@@ -180,7 +180,7 @@ Now you'll need to setup your bot on the [Discord Developer Portal](https://disc
 <Cards>
   <Card
     icon={<LayoutDashboard />}
-    href="/"
+    href="/carbon/helpful-guides/developer-portal/urls"
     title="Discord Developer Portal"
     description="Learn how to setup your bot on the Discord Developer Portal."
   />

--- a/website/content/carbon/getting-started/nextjs.mdx
+++ b/website/content/carbon/getting-started/nextjs.mdx
@@ -113,7 +113,7 @@ Now you'll need to setup your bot on the [Discord Developer Portal](https://disc
 <Cards>
   <Card
     icon={<LayoutDashboard />}
-    href="/"
+    href="/carbon/helpful-guides/developer-portal/urls"
     title="Discord Developer Portal"
     description="Learn how to setup your bot on the Discord Developer Portal."
   />

--- a/website/content/carbon/getting-started/nodejs.mdx
+++ b/website/content/carbon/getting-started/nodejs.mdx
@@ -140,7 +140,7 @@ Now you'll need to setup your bot on the [Discord Developer Portal](https://disc
 <Cards>
   <Card
     icon={<LayoutDashboard />}
-    href="/"
+    href="/carbon/helpful-guides/developer-portal/urls"
     title="Discord Developer Portal"
     description="Learn how to setup your bot on the Discord Developer Portal."
   />

--- a/website/content/carbon/getting-started/nodejs.mdx
+++ b/website/content/carbon/getting-started/nodejs.mdx
@@ -58,7 +58,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 ```
 
 Now, let's make our Client.
-```
+```ts
 const client = new Client(
 	{
 		clientId: process.env.CLIENT_ID,


### PR DESCRIPTION
Fixes the developer portal button on most of the guides and adds formatting to a code block in the NodeJS guide
![image](https://github.com/user-attachments/assets/f885a48a-506b-4c71-bca8-acd136e857f3)
![image](https://github.com/user-attachments/assets/0a681b8c-320e-4cba-a9a6-a8a90bc3a549)
