### PR TITLE
fix: `OptionsHandler#getMentionable` always returning user

### DIFF
--- a/.changeset/beige-melons-teach.md
+++ b/.changeset/beige-melons-teach.md
@@ -1,0 +1,5 @@
+---
+"@buape/carbon": patch
+---
+
+fix: `OptionsHandler#getMentionable` always returning user even when invalid

--- a/packages/carbon/src/internals/OptionsHandler.ts
+++ b/packages/carbon/src/internals/OptionsHandler.ts
@@ -202,10 +202,13 @@ export class OptionsHandler extends Base {
 			if (!id || typeof id !== "string")
 				throw new Error(`Missing required option: ${key}`)
 		} else if (!id || typeof id !== "string") return undefined
-		const user = new User(this.client, id)
-		await user.fetch().catch(() => {
+
+		try {
+			const user = new User(this.client, id)
+			await user.fetch()
+			return user
+		} catch {
 			return new Role(this.client, id)
-		})
-		return user
+		}
 	}
 }


### PR DESCRIPTION
[Before Playground](https://evaluate.run/playgrounds/javascript+node#eJxdT1sKgzAQvMp2f6IgHiBgT+JPiEndYjclWftAvHsT+0D6NzPMg1nQ0+QS6gW1NvGUtEaN2GRGfJ3lS4kH92jP2YgmPdmCn9kKBQbvxI7VnFysYekZgDxsFA5dB6ogVYOMMdxBEd/MRIPqee2557+qiyGuPi02cBLYerp9DsDcDcl+trWm4JzsjrBAdDJHBhXD5BSsdcl8tGLfpt9LrYyOq7KUre0UTjWuDTqW+Mw/f5cb9MHm6LAX1xeXh2kz)

[After Playground](https://evaluate.run/playgrounds/javascript+node#eJxdkE2OwyAMha/i8YZEinIApNwkG0SgcZUxFTj9UcTdS0g7imZnv2c+P7Ohp8Ul1BtqbeIlaY0asSsd8W2Vb0s8uWd/LYNo0ost+JWtUGDwTuzcrMnFFraRAchDbeFnGEDtlWpB5hgeoIjvZqFJjZxHHvkf6tcQNx+KxNdRANjASaAihzNi98zDkJwzHHJ0skaub3YhgzVl4gv8uCqGxVVOrnmO9b3Mjpt9Z3H7JVxazB06LoHK8X//0KEPtvCns5jf91ZvRw)