### PR TITLE
Adjust required node version

### DIFF
--- a/.changeset/famous-fishes-brush.md
+++ b/.changeset/famous-fishes-brush.md
@@ -1,0 +1,8 @@
+---
+"@buape/carbon": minor
+"create-carbon": minor
+"@buape/carbon-nodejs": minor
+"@buape/carbon-request": minor
+---
+
+feat: Bump required node version to v20

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,7 +9,7 @@ runs:
         - name: Setup Node.js environment
           uses: actions/setup-node@v4
           with:
-              node-version: 22
+              node-version: 20
               cache: pnpm
 
         - name: Install dependencies

--- a/apps/rocko/package.json
+++ b/apps/rocko/package.json
@@ -11,7 +11,7 @@
 	"dependencies": {
 		"@buape/carbon": "workspace:*",
 		"@buape/carbon-nodejs": "workspace:*",
-		"@types/node": "22.5.5"
+		"@types/node": "^20"
 	},
 	"license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
 		"typescript": "5.6.2",
 		"vitest": "2.1.1"
 	},
-	"packageManager": "pnpm@9.11.0"
+	"packageManager": "pnpm@9.11.0",
+	"engines": {
+		"node": ">=20"
+	}
 }

--- a/packages/carbon/package.json
+++ b/packages/carbon/package.json
@@ -22,7 +22,7 @@
 	"license": "MIT",
 	"dependencies": {
 		"@buape/carbon-request": "workspace:*",
-		"@types/node": "20",
+		"@types/node": "^20",
 		"discord-api-types": "0.37.100",
 		"discord-verify": "1.2.0",
 		"itty-router": "5.0.18"

--- a/packages/create-carbon/package.json
+++ b/packages/create-carbon/package.json
@@ -21,7 +21,7 @@
 		"yocto-spinner": "^0.1.0"
 	},
 	"devDependencies": {
-		"@types/node": "^22.5.5"
+		"@types/node": "^20"
 	},
 	"bin": "./dist/src/index.js"
 }

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -12,7 +12,7 @@
 	"license": "MIT",
 	"dependencies": {
 		"@hono/node-server": "1.13.1",
-		"@types/node": "22.5.5",
+		"@types/node": "^20",
 		"path": "0.12.7"
 	},
 	"peerDependencies": {

--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -12,7 +12,7 @@
 	"license": "MIT",
 	"dependencies": {},
 	"engines": {
-		"node": ">=18"
+		"node": ">=20"
 	},
 	"files": [
 		"dist",


### PR DESCRIPTION
Fixes #143

Update the required Node.js version to v20+ and adjust `@types/node` packages to ^20.

* **packages/request/package.json**
  - Update the `engines` field to specify Node.js version ">=20".
* **.github/actions/setup/action.yml**
  - Update the `node-version` field to "20".
* **package.json**
  - Add an `engines` field specifying Node.js version ">=20".
* **packages/carbon/package.json**
  - Update the `@types/node` dependency to "^20".
* **packages/nodejs/package.json**
  - Update the `@types/node` dependency to "^20".
* **apps/rocko/package.json**
  - Update the `@types/node` dependency to "^20".
* **packages/create-carbon/package.json**
  - Update the `@types/node` dependency to "^20".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/buape/carbon/issues/143?shareId=b74e42ba-6e38-43b2-b00d-03eea6e9cb8e).