### PR TITLE
fix: fixed sharding on createIdentifyPayload

### DIFF
--- a/.changeset/spicy-shirts-jam.md
+++ b/.changeset/spicy-shirts-jam.md
@@ -1,0 +1,5 @@
+---
+"@buape/carbon": patch
+---
+
+feat: fixed sharding on createIdentifyPayload

--- a/.changeset/spicy-shirts-jam.md
+++ b/.changeset/spicy-shirts-jam.md
@@ -2,4 +2,4 @@
 "@buape/carbon": patch
 ---
 
-feat: fixed sharding on createIdentifyPayload
+fix: fixed sharding on createIdentifyPayload

--- a/packages/carbon/src/plugins/gateway/utils/payload.ts
+++ b/packages/carbon/src/plugins/gateway/utils/payload.ts
@@ -10,6 +10,7 @@ interface IdentifyData {
 	token: string
 	properties: IdentifyProperties
 	intents: number
+	shard?: [number, number]
 }
 
 interface ResumeData {
@@ -52,7 +53,8 @@ export function createIdentifyPayload(data: IdentifyData): GatewayPayload {
 		d: {
 			token: data.token,
 			properties: data.properties,
-			intents: data.intents
+			intents: data.intents,
+			...(data.shard ? { shard: data.shard } : {}),
 		}
 	}
 }

--- a/packages/carbon/src/plugins/gateway/utils/payload.ts
+++ b/packages/carbon/src/plugins/gateway/utils/payload.ts
@@ -54,7 +54,7 @@ export function createIdentifyPayload(data: IdentifyData): GatewayPayload {
 			token: data.token,
 			properties: data.properties,
 			intents: data.intents,
-			...(data.shard ? { shard: data.shard } : {}),
+			...(data.shard ? { shard: data.shard } : {})
 		}
 	}
 }


### PR DESCRIPTION
This fixes an issue where sharding bots don't work:
![image](https://github.com/user-attachments/assets/0075ba29-fbc4-4923-8ff5-4bb71c42b2e5)

This is due to the lack of "shard" in the function `createIdentityPayload`:
![image](https://github.com/user-attachments/assets/780851ad-8489-42f0-833f-e5709845f311)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved support for sharding information in the identify payload to enhance compatibility with sharded environments.
- **Chores**
  - Added documentation for the patch update related to sharding support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->