### PR TITLE
feat: one off components (e.g. confirmation prompts)

### DIFF
--- a/.changeset/silver-snakes-refuse.md
+++ b/.changeset/silver-snakes-refuse.md
@@ -1,0 +1,5 @@
+---
+"@buape/carbon": minor
+---
+
+feat: Message#disableAllButtons

--- a/.changeset/slick-brooms-attack.md
+++ b/.changeset/slick-brooms-attack.md
@@ -1,0 +1,5 @@
+---
+"@buape/carbon": minor
+---
+
+feat: one off components (e.g. confirmation prompts)

--- a/.changeset/swift-emus-stop.md
+++ b/.changeset/swift-emus-stop.md
@@ -1,0 +1,5 @@
+---
+"@buape/carbon": minor
+---
+
+feat: have Interaction#reply return a Message you can use

--- a/apps/cloudo/tsconfig.json
+++ b/apps/cloudo/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"include": ["src"],
+	"include": ["src", "../rocko/src/commands/testing/confirm.ts"],
 	"exclude": ["node_modules", "dist"],
 	"compilerOptions": {
 		"strict": true,

--- a/apps/cloudo/tsconfig.json
+++ b/apps/cloudo/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"include": ["src", "../rocko/src/commands/testing/confirm.ts"],
+	"include": ["src"],
 	"exclude": ["node_modules", "dist"],
 	"compilerOptions": {
 		"strict": true,

--- a/apps/rocko/src/commands/testing/confirm.ts
+++ b/apps/rocko/src/commands/testing/confirm.ts
@@ -1,0 +1,49 @@
+import {
+	Button,
+	type ButtonInteraction,
+	ButtonStyle,
+	Command,
+	type CommandInteraction,
+	Row
+} from "@buape/carbon"
+
+export default class ConfirmCommand extends Command {
+	name = "confirm"
+	description = "Confirm a message"
+	async run(interaction: CommandInteraction) {
+		const done = await interaction.replyAndWaitForComponent({
+			content: "Confirm the message",
+			components: [
+				new Row([
+					new (class extends Button {
+						label = "Confirm"
+						style = ButtonStyle.Success
+						customId = "x-confirm"
+						async run(interaction: ButtonInteraction) {
+							return interaction.acknowledge()
+						}
+					})(),
+					new (class extends Button {
+						label = "Cancel"
+						style = ButtonStyle.Danger
+						customId = "x-cancel"
+						async run(interaction: ButtonInteraction) {
+							return interaction.acknowledge()
+						}
+					})()
+				])
+			]
+		})
+		if (done.success) {
+			await interaction.message?.disableAllButtons()
+			interaction.followUp({
+				content: `Confirmed: ${done.customId}`
+			})
+		} else {
+			await interaction.message?.disableAllButtons()
+			interaction.followUp({
+				content: done.reason
+			})
+		}
+	}
+}

--- a/apps/rocko/src/commands/testing/confirm.ts
+++ b/apps/rocko/src/commands/testing/confirm.ts
@@ -1,6 +1,5 @@
 import {
 	Button,
-	type ButtonInteraction,
 	ButtonStyle,
 	Command,
 	type CommandInteraction,
@@ -13,26 +12,7 @@ export default class ConfirmCommand extends Command {
 	async run(interaction: CommandInteraction) {
 		const done = await interaction.replyAndWaitForComponent({
 			content: "Confirm the message",
-			components: [
-				new Row([
-					new (class extends Button {
-						label = "Confirm"
-						style = ButtonStyle.Success
-						customId = "x-confirm"
-						async run(interaction: ButtonInteraction) {
-							return interaction.acknowledge()
-						}
-					})(),
-					new (class extends Button {
-						label = "Cancel"
-						style = ButtonStyle.Danger
-						customId = "x-cancel"
-						async run(interaction: ButtonInteraction) {
-							return interaction.acknowledge()
-						}
-					})()
-				])
-			]
+			components: [new Row([new ConfirmButton(), new CancelButton()])]
 		})
 		if (done.success) {
 			await interaction.message?.disableAllButtons()
@@ -46,4 +26,16 @@ export default class ConfirmCommand extends Command {
 			})
 		}
 	}
+}
+
+class ConfirmButton extends Button {
+	label = "Confirm"
+	style = ButtonStyle.Success
+	customId = "x-confirm"
+}
+
+class CancelButton extends Button {
+	label = "Cancel"
+	style = ButtonStyle.Danger
+	customId = "x-cancel"
 }

--- a/apps/rocko/src/index.ts
+++ b/apps/rocko/src/index.ts
@@ -11,6 +11,7 @@ import MentionsCommand from "./commands/testing/allow_mentions.js"
 import AttachmentCommand from "./commands/testing/attachment.js"
 import ButtonCommand from "./commands/testing/button.js"
 import ComponentsV2 from "./commands/testing/components_v2.js"
+import ConfirmCommand from "./commands/testing/confirm.js"
 import EphemeralCommand from "./commands/testing/ephemeral.js"
 import EverySelectCommand from "./commands/testing/every_select.js"
 import MessageCommand from "./commands/testing/message_command.js"
@@ -73,7 +74,8 @@ const client = new Client(
 			new UserCommand(),
 			new MentionsCommand(),
 			new PrecheckCommand(),
-			new PaginatorCommand()
+			new PaginatorCommand(),
+			new ConfirmCommand()
 		],
 		listeners: [new ApplicationAuthorized(), new MessageCreate()]
 	},
@@ -103,3 +105,5 @@ declare global {
 		}
 	}
 }
+
+//

--- a/packages/carbon/src/abstracts/AnySelectMenu.ts
+++ b/packages/carbon/src/abstracts/AnySelectMenu.ts
@@ -22,7 +22,7 @@ export abstract class AnySelectMenu extends BaseMessageInteractiveComponent {
 	abstract run(
 		interaction: AnySelectMenuInteraction,
 		data: ComponentData
-	): Promise<void>
+	): unknown | Promise<unknown>
 
 	minValues?: number
 	maxValues?: number

--- a/packages/carbon/src/abstracts/BaseInteraction.ts
+++ b/packages/carbon/src/abstracts/BaseInteraction.ts
@@ -265,25 +265,20 @@ export abstract class BaseInteraction<T extends APIInteraction> extends Base {
 	> {
 		const message = await this.reply(data, true)
 
-		return new Promise((resolve, reject) => {
+		const id: `${string}-${string}` = `${message.id}-${message.channelId}`
+
+		return new Promise((resolve) => {
 			const timer = setTimeout(() => {
-				this.client.componentHandler.oneOffComponents.delete(
-					`${message.id}-${message.channelId}`
-				)
-				reject({ success: false, reason: "timed out" })
+				this.client.componentHandler.oneOffComponents.delete(id)
+				resolve({ success: false, reason: "timed out" })
 			}, timeout)
-			this.client.componentHandler.oneOffComponents.set(
-				`${message.id}-${message.channelId}`,
-				{
-					resolve: (id: string) => {
-						clearTimeout(timer)
-						this.client.componentHandler.oneOffComponents.delete(
-							`${message.id}-${message.channelId}`
-						)
-						resolve({ success: true, customId: id })
-					}
+			this.client.componentHandler.oneOffComponents.set(id, {
+				resolve: (customId: string) => {
+					clearTimeout(timer)
+					this.client.componentHandler.oneOffComponents.delete(id)
+					resolve({ success: true, customId })
 				}
-			)
+			})
 		})
 	}
 }

--- a/packages/carbon/src/abstracts/BaseMessageInteractiveComponent.ts
+++ b/packages/carbon/src/abstracts/BaseMessageInteractiveComponent.ts
@@ -51,8 +51,14 @@ export abstract class BaseMessageInteractiveComponent extends BaseComponent {
 	customIdParser: (id: string) => ComponentParserResult = parseCustomId
 
 	abstract serialize: () => APIComponentInMessageActionRow
-	abstract run(
+
+	run(
 		interaction: BaseComponentInteraction,
 		data: ComponentData
-	): Promise<unknown>
+	): unknown | Promise<unknown> {
+		// Random things to show the vars as used
+		typeof interaction === "string"
+		typeof data === "string"
+		return
+	}
 }

--- a/packages/carbon/src/abstracts/BaseMessageInteractiveComponent.ts
+++ b/packages/carbon/src/abstracts/BaseMessageInteractiveComponent.ts
@@ -54,5 +54,5 @@ export abstract class BaseMessageInteractiveComponent extends BaseComponent {
 	abstract run(
 		interaction: BaseComponentInteraction,
 		data: ComponentData
-	): Promise<void>
+	): Promise<unknown>
 }

--- a/packages/carbon/src/classes/Command.ts
+++ b/packages/carbon/src/classes/Command.ts
@@ -29,7 +29,7 @@ export abstract class Command extends BaseCommand {
 	 * The function that is called when the command is ran
 	 * @param interaction The interaction that triggered the command
 	 */
-	abstract run(interaction: CommandInteraction): Promise<void>
+	abstract run(interaction: CommandInteraction): unknown | Promise<unknown>
 
 	/**
 	 * The function that is called when the command's autocomplete is triggered.

--- a/packages/carbon/src/classes/Modal.ts
+++ b/packages/carbon/src/classes/Modal.ts
@@ -45,7 +45,7 @@ export abstract class Modal {
 	abstract run(
 		interaction: ModalInteraction,
 		data: ComponentData
-	): Promise<void>
+	): unknown | Promise<unknown>
 
 	serialize = (): APIModalInteractionResponseCallbackData => {
 		return {

--- a/packages/carbon/src/classes/RequestClient.ts
+++ b/packages/carbon/src/classes/RequestClient.ts
@@ -56,7 +56,7 @@ export type QueuedRequest = {
 	method: string
 	path: string
 	data?: RequestData
-	query?: Record<string, string>
+	query?: Record<string, string | number | boolean>
 	resolve: (value?: unknown) => void
 	reject: (reason?: unknown) => void
 }
@@ -96,29 +96,37 @@ export class RequestClient {
 		}
 	}
 
-	async get(path: string, query?: Record<string, string>) {
+	async get(path: string, query?: QueuedRequest["query"]) {
 		return await this.request("GET", path, { query })
 	}
 
-	async post(path: string, data?: RequestData) {
-		return await this.request("POST", path, { data })
+	async post(path: string, data?: RequestData, query?: QueuedRequest["query"]) {
+		return await this.request("POST", path, { data, query })
 	}
 
-	async patch(path: string, data?: RequestData) {
-		return await this.request("PATCH", path, { data })
+	async patch(
+		path: string,
+		data?: RequestData,
+		query?: QueuedRequest["query"]
+	) {
+		return await this.request("PATCH", path, { data, query })
 	}
 
-	async put(path: string, data?: RequestData) {
-		return await this.request("PUT", path, { data })
+	async put(path: string, data?: RequestData, query?: QueuedRequest["query"]) {
+		return await this.request("PUT", path, { data, query })
 	}
 
-	async delete(path: string, data?: RequestData) {
-		return await this.request("DELETE", path, { data })
+	async delete(
+		path: string,
+		data?: RequestData,
+		query?: QueuedRequest["query"]
+	) {
+		return await this.request("DELETE", path, { data, query })
 	}
 	private async request(
 		method: string,
 		path: string,
-		{ data, query }: { data?: RequestData; query?: Record<string, string> }
+		{ data, query }: { data?: RequestData; query?: QueuedRequest["query"] }
 	): Promise<unknown> {
 		if (this.options.queueRequests) {
 			return new Promise((resolve, reject) => {
@@ -139,7 +147,18 @@ export class RequestClient {
 		await this.waitForRateLimit()
 
 		const { method, path, data, query } = request
-		const url = `${this.options.baseUrl}${path}${query ? `?${new URLSearchParams(query).toString()}` : ""}`
+		const queryString = query
+			? `?${Object.entries(query)
+					.map(
+						([key, value]) =>
+							`${encodeURIComponent(key)}=${encodeURIComponent(value)}`
+					)
+					.join("&")}`
+			: ""
+		const url = `${this.options.baseUrl}${path}${queryString}`
+		console.log(`Request: ${JSON.stringify(request)}`)
+		console.log(`URL: ${url}`)
+		console.log(`Query: ${queryString} (${query})`)
 		const headers = new Headers({
 			Authorization: `${this.options.tokenHeader} ${this.token}`
 		})
@@ -266,13 +285,14 @@ export class RequestClient {
 		const queueItem = this.queue.shift()
 		if (!queueItem) return
 
-		const { method, path, data, resolve, reject } = queueItem
+		const { method, path, data, query, resolve, reject } = queueItem
 
 		try {
 			const result = await this.executeRequest({
 				method,
 				path,
 				data,
+				query,
 				resolve,
 				reject
 			})

--- a/packages/carbon/src/classes/RequestClient.ts
+++ b/packages/carbon/src/classes/RequestClient.ts
@@ -156,9 +156,6 @@ export class RequestClient {
 					.join("&")}`
 			: ""
 		const url = `${this.options.baseUrl}${path}${queryString}`
-		console.log(`Request: ${JSON.stringify(request)}`)
-		console.log(`URL: ${url}`)
-		console.log(`Query: ${queryString} (${query})`)
 		const headers = new Headers({
 			Authorization: `${this.options.tokenHeader} ${this.token}`
 		})

--- a/packages/carbon/src/classes/components/Button.ts
+++ b/packages/carbon/src/classes/components/Button.ts
@@ -37,10 +37,15 @@ abstract class BaseButton extends BaseMessageInteractiveComponent {
 }
 
 export abstract class Button extends BaseButton {
-	abstract run(
+	run(
 		interaction: ButtonInteraction,
 		data: ComponentData
-	): Promise<unknown>
+	): unknown | Promise<unknown> {
+		// Random things to show the vars as used
+		typeof interaction === "string"
+		typeof data === "string"
+		return
+	}
 
 	serialize = (): APIButtonComponent => {
 		if (this.style === ButtonStyle.Link) {

--- a/packages/carbon/src/classes/components/Button.ts
+++ b/packages/carbon/src/classes/components/Button.ts
@@ -40,7 +40,7 @@ export abstract class Button extends BaseButton {
 	abstract run(
 		interaction: ButtonInteraction,
 		data: ComponentData
-	): Promise<void>
+	): Promise<unknown>
 
 	serialize = (): APIButtonComponent => {
 		if (this.style === ButtonStyle.Link) {

--- a/packages/carbon/src/classes/components/ChannelSelectMenu.ts
+++ b/packages/carbon/src/classes/components/ChannelSelectMenu.ts
@@ -14,7 +14,7 @@ export abstract class ChannelSelectMenu extends AnySelectMenu {
 	abstract run(
 		interaction: ChannelSelectMenuInteraction,
 		data: ComponentData
-	): Promise<void>
+	): unknown | Promise<unknown>
 
 	serializeOptions() {
 		return {

--- a/packages/carbon/src/classes/components/MentionableSelectMenu.ts
+++ b/packages/carbon/src/classes/components/MentionableSelectMenu.ts
@@ -13,7 +13,7 @@ export abstract class MentionableSelectMenu extends AnySelectMenu {
 	abstract run(
 		interaction: MentionableSelectMenuInteraction,
 		data: ComponentData
-	): Promise<void>
+	): unknown | Promise<unknown>
 
 	serializeOptions() {
 		return {

--- a/packages/carbon/src/classes/components/RoleSelectMenu.ts
+++ b/packages/carbon/src/classes/components/RoleSelectMenu.ts
@@ -13,7 +13,7 @@ export abstract class RoleSelectMenu extends AnySelectMenu {
 	abstract run(
 		interaction: RoleSelectMenuInteraction,
 		data: ComponentData
-	): Promise<void>
+	): unknown | Promise<unknown>
 
 	serializeOptions() {
 		return {

--- a/packages/carbon/src/classes/components/StringSelectMenu.ts
+++ b/packages/carbon/src/classes/components/StringSelectMenu.ts
@@ -13,7 +13,7 @@ export abstract class StringSelectMenu extends AnySelectMenu {
 	abstract run(
 		interaction: StringSelectMenuInteraction,
 		data: ComponentData
-	): Promise<void>
+	): unknown | Promise<unknown>
 
 	serializeOptions() {
 		return {

--- a/packages/carbon/src/classes/components/UserSelectMenu.ts
+++ b/packages/carbon/src/classes/components/UserSelectMenu.ts
@@ -13,7 +13,7 @@ export abstract class UserSelectMenu extends AnySelectMenu {
 	abstract run(
 		interaction: UserSelectMenuInteraction,
 		data: ComponentData
-	): Promise<void>
+	): unknown | Promise<unknown>
 
 	serializeOptions() {
 		return {

--- a/packages/carbon/src/internals/AutocompleteInteraction.ts
+++ b/packages/carbon/src/internals/AutocompleteInteraction.ts
@@ -37,11 +37,11 @@ export class AutocompleteInteraction extends BaseInteraction<APIApplicationComma
 		)
 	}
 
-	override async defer() {
+	override async defer(): Promise<never> {
 		throw new Error("Defer is not available for autocomplete interactions")
 	}
 
-	override async reply() {
+	override async reply(): Promise<never> {
 		throw new Error("Reply is not available for autocomplete interactions")
 	}
 

--- a/packages/carbon/src/internals/ComponentHandler.ts
+++ b/packages/carbon/src/internals/ComponentHandler.ts
@@ -1,7 +1,10 @@
+import { Routes } from "discord-api-types/v9"
+import { InteractionResponseType } from "discord-api-types/v9"
 import type {
 	APIMessageComponentButtonInteraction,
 	APIMessageComponentInteraction,
-	APIMessageComponentSelectMenuInteraction
+	APIMessageComponentSelectMenuInteraction,
+	RESTPostAPIInteractionCallbackJSONBody
 } from "discord-api-types/v10"
 import { Base } from "../abstracts/Base.js"
 import type { BaseMessageInteractiveComponent } from "../abstracts/BaseMessageInteractiveComponent.js"
@@ -20,6 +23,13 @@ import { UserSelectMenuInteraction } from "./UserSelectMenuInteraction.js"
 
 export class ComponentHandler extends Base {
 	components: BaseMessageInteractiveComponent[] = []
+
+	oneOffComponents: Map<
+		`${string}-${string}`,
+		{
+			resolve: (id: string) => void
+		}
+	> = new Map()
 	/**
 	 * Register a component with the handler
 	 * @internal
@@ -41,7 +51,27 @@ export class ComponentHandler extends Base {
 				componentKey === interactionKey && x.type === data.data.component_type
 			)
 		})
-		if (!component) return false
+		if (!component) {
+			const oneOffComponent = this.oneOffComponents.get(
+				`${data.message.id}-${data.message.channel_id}`
+			)
+
+			if (oneOffComponent) {
+				oneOffComponent.resolve(data.data.custom_id)
+				this.oneOffComponents.delete(
+					`${data.message.id}-${data.message.channel_id}`
+				)
+				await this.client.rest.post(
+					Routes.interactionCallback(data.id, data.token),
+					{
+						body: {
+							type: InteractionResponseType.DeferredMessageUpdate
+						} as RESTPostAPIInteractionCallbackJSONBody
+					}
+				)
+			}
+			return
+		}
 
 		const parsed = component.customIdParser(data.data.custom_id)
 

--- a/packages/carbon/src/internals/ComponentHandler.ts
+++ b/packages/carbon/src/internals/ComponentHandler.ts
@@ -1,10 +1,10 @@
-import { Routes } from "discord-api-types/v9"
-import { InteractionResponseType } from "discord-api-types/v9"
-import type {
-	APIMessageComponentButtonInteraction,
-	APIMessageComponentInteraction,
-	APIMessageComponentSelectMenuInteraction,
-	RESTPostAPIInteractionCallbackJSONBody
+import {
+	type APIMessageComponentButtonInteraction,
+	type APIMessageComponentInteraction,
+	type APIMessageComponentSelectMenuInteraction,
+	InteractionResponseType,
+	type RESTPostAPIInteractionCallbackJSONBody,
+	Routes
 } from "discord-api-types/v10"
 import { Base } from "../abstracts/Base.js"
 import type { BaseMessageInteractiveComponent } from "../abstracts/BaseMessageInteractiveComponent.js"
@@ -61,14 +61,17 @@ export class ComponentHandler extends Base {
 				this.oneOffComponents.delete(
 					`${data.message.id}-${data.message.channel_id}`
 				)
-				await this.client.rest.post(
-					Routes.interactionCallback(data.id, data.token),
-					{
+				await this.client.rest
+					.post(Routes.interactionCallback(data.id, data.token), {
 						body: {
 							type: InteractionResponseType.DeferredMessageUpdate
 						} as RESTPostAPIInteractionCallbackJSONBody
-					}
-				)
+					})
+					.catch(() => {
+						console.warn(
+							`Failed to acknowledge one-off component interaction for message ${data.message.id}`
+						)
+					})
 			}
 			return
 		}

--- a/packages/carbon/src/structures/Message.ts
+++ b/packages/carbon/src/structures/Message.ts
@@ -428,7 +428,7 @@ export class Message<IsPartial extends boolean = false> extends Base {
 	async disableAllButtons() {
 		if (!this.rawData) return
 		if (!this.rawData.components) return
-		await this.client.rest.patch(
+		const patched = (await this.client.rest.patch(
 			Routes.channelMessage(this.channelId, this.id),
 			{
 				body: {
@@ -441,7 +441,7 @@ export class Message<IsPartial extends boolean = false> extends Base {
 										...component,
 										components: component.components.map((c) => ({
 											...c,
-											disabled: true
+											...("disabled" in c ? { disabled: true } : {})
 										}))
 									}
 								}
@@ -466,6 +466,7 @@ export class Message<IsPartial extends boolean = false> extends Base {
 						}) ?? []
 				} satisfies RESTPatchAPIChannelMessageJSONBody
 			}
-		)
+		)) as APIMessage
+		this.setData(patched)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "confirm" command that prompts users to confirm actions with interactive buttons.
  - Introduced support for one-off components such as confirmation prompts.
  - Added new message actions: edit, forward, reply, and disable all buttons on messages.
  - Enhanced interaction replies to return message objects for further handling.
  - Added the ability to wait for component interactions with a timeout.

- **Improvements**
  - Expanded support for query parameters in API requests to include numbers and booleans.
  - Broadened command and component handler flexibility by allowing more flexible method return types.
  - Improved handling of one-off component interactions for better user experience.

- **Bug Fixes**
  - Ensured message channel IDs are always defined to prevent errors in message actions.

- **Chores**
  - Updated documentation and metadata to reflect new features and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->