### PR TITLE
Allow accessing a readable rawData (proof of concept, don't accept the PR)

### DIFF
--- a/packages/carbon/src/structures/Guild.ts
+++ b/packages/carbon/src/structures/Guild.ts
@@ -44,8 +44,9 @@ export class Guild<IsPartial extends boolean = false> extends Base {
 
 	protected _rawData: APIGuild | null = null
 	get rawData(): Readonly<APIGuild> {
-		if (!this._rawData) throw new Error("Cannot get data without having data... smh")
-		return this._rawData;
+		if (!this._rawData)
+			throw new Error("Cannot get data without having data... smh")
+		return this._rawData
 	}
 	private setData(data: typeof this._rawData) {
 		if (!data) throw new Error("Cannot set data without having data... smh")

--- a/packages/carbon/src/structures/Guild.ts
+++ b/packages/carbon/src/structures/Guild.ts
@@ -36,22 +36,26 @@ export class Guild<IsPartial extends boolean = false> extends Base {
 		if (typeof rawDataOrId === "string") {
 			this.id = rawDataOrId
 		} else {
-			this.rawData = rawDataOrId
+			this._rawData = rawDataOrId
 			this.id = rawDataOrId.id
 			this.setData(rawDataOrId)
 		}
 	}
 
-	protected rawData: APIGuild | null = null
-	private setData(data: typeof this.rawData) {
+	protected _rawData: APIGuild | null = null
+	get rawData(): Readonly<APIGuild> {
+		if (!this._rawData) throw new Error("Cannot get data without having data... smh")
+		return this._rawData;
+	}
+	private setData(data: typeof this._rawData) {
 		if (!data) throw new Error("Cannot set data without having data... smh")
-		this.rawData = data
+		this._rawData = data
 	}
 
 	private setField(key: keyof APIGuild, value: unknown) {
-		if (!this.rawData)
+		if (!this._rawData)
 			throw new Error("Cannot set field without having data... smh")
-		Reflect.set(this.rawData, key, value)
+		Reflect.set(this._rawData, key, value)
 	}
 
 	/**
@@ -64,23 +68,23 @@ export class Guild<IsPartial extends boolean = false> extends Base {
 	 * If this is true, you should use {@link Guild.fetch} to get the full data of the guild.
 	 */
 	get partial(): IfPartial<IsPartial, false, true> {
-		return (this.rawData === null) as never
+		return (this._rawData === null) as never
 	}
 
 	/**
 	 * The name of the guild.
 	 */
 	get name(): IfPartial<IsPartial, string> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.name as never
+		if (!this._rawData) return undefined as never
+		return this._rawData.name as never
 	}
 
 	/**
 	 * The description of the guild.
 	 */
 	get description(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.description as never
+		if (!this._rawData) return undefined as never
+		return this._rawData.description as never
 	}
 
 	/**
@@ -88,15 +92,15 @@ export class Guild<IsPartial extends boolean = false> extends Base {
 	 * You can use {@link Guild.iconUrl} to get the URL of the icon.
 	 */
 	get icon(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.icon
+		if (!this._rawData) return undefined as never
+		return this._rawData.icon
 	}
 
 	/**
 	 * Get the URL of the guild's icon
 	 */
 	get iconUrl(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
+		if (!this._rawData) return undefined as never
 		if (!this.icon) return null
 		return `https://cdn.discordapp.com/icons/${this.id}/${this.icon}.png`
 	}
@@ -106,15 +110,15 @@ export class Guild<IsPartial extends boolean = false> extends Base {
 	 * You can use {@link Guild.splashUrl} to get the URL of the splash.
 	 */
 	get splash(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.splash
+		if (!this._rawData) return undefined as never
+		return this._rawData.splash
 	}
 
 	/**
 	 * Get the URL of the guild's splash
 	 */
 	get splashUrl(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
+		if (!this._rawData) return undefined as never
 		if (!this.splash) return null
 		return `https://cdn.discordapp.com/splashes/${this.id}/${this.splash}.png`
 	}
@@ -123,16 +127,16 @@ export class Guild<IsPartial extends boolean = false> extends Base {
 	 * The ID of the owner of the guild.
 	 */
 	get ownerId(): IfPartial<IsPartial, string> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.owner_id
+		if (!this._rawData) return undefined as never
+		return this._rawData.owner_id
 	}
 
 	/**
 	 * Get all roles in the guild
 	 */
 	get roles(): IfPartial<IsPartial, Role[]> {
-		if (!this.rawData) return undefined as never
-		const roles = this.rawData?.roles
+		if (!this._rawData) return undefined as never
+		const roles = this._rawData?.roles
 		if (!roles) throw new Error("Cannot get roles without having data... smh")
 		return roles.map((role) => new Role(this.client, role))
 	}
@@ -141,8 +145,8 @@ export class Guild<IsPartial extends boolean = false> extends Base {
 	 * The preferred locale of the guild.
 	 */
 	get preferredLocale(): IfPartial<IsPartial, string> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.preferred_locale
+		if (!this._rawData) return undefined as never
+		return this._rawData.preferred_locale
 	}
 
 	/**
@@ -150,15 +154,15 @@ export class Guild<IsPartial extends boolean = false> extends Base {
 	 * You can use {@link Guild.discoverySplashUrl} to get the URL of the discovery splash.
 	 */
 	get discoverySplash(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.discovery_splash
+		if (!this._rawData) return undefined as never
+		return this._rawData.discovery_splash
 	}
 
 	/**
 	 * Get the URL of the guild's discovery splash
 	 */
 	get discoverySplashUrl(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
+		if (!this._rawData) return undefined as never
 		if (!this.discoverySplash) return null
 		return `https://cdn.discordapp.com/discovery-splashes/${this.id}/${this.discoverySplash}.png`
 	}
@@ -167,56 +171,56 @@ export class Guild<IsPartial extends boolean = false> extends Base {
 	 * Whether the user is the owner of the guild
 	 */
 	get owner(): IfPartial<IsPartial, boolean> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.owner ?? false
+		if (!this._rawData) return undefined as never
+		return this._rawData.owner ?? false
 	}
 
 	/**
 	 * Total permissions for the user in the guild (excludes overrides)
 	 */
 	get permissions(): IfPartial<IsPartial, bigint> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.permissions as never
+		if (!this._rawData) return undefined as never
+		return this._rawData.permissions as never
 	}
 
 	/**
 	 * ID of afk channel
 	 */
 	get afkChannelId(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.afk_channel_id
+		if (!this._rawData) return undefined as never
+		return this._rawData.afk_channel_id
 	}
 
 	/**
 	 * afk timeout in seconds, can be set to: `60`, `300`, `900`, `1800`, `3600`
 	 */
 	get afkTimeout(): IfPartial<IsPartial, 1800 | 3600 | 60 | 300 | 900> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.afk_timeout
+		if (!this._rawData) return undefined as never
+		return this._rawData.afk_timeout
 	}
 
 	/**
 	 * Whether the guild widget is enabled
 	 */
 	get widgetEnabled(): IfPartial<IsPartial, boolean> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.widget_enabled ?? false
+		if (!this._rawData) return undefined as never
+		return this._rawData.widget_enabled ?? false
 	}
 
 	/**
 	 * The channel id that the widget will generate an invite to, or `null` if set to no invite
 	 */
 	get widgetChannelId(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.widget_channel_id ?? null
+		if (!this._rawData) return undefined as never
+		return this._rawData.widget_channel_id ?? null
 	}
 
 	/**
 	 * Verification level required for the guild
 	 */
 	get verificationLevel(): IfPartial<IsPartial, GuildVerificationLevel> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.verification_level
+		if (!this._rawData) return undefined as never
+		return this._rawData.verification_level
 	}
 
 	/**
@@ -226,8 +230,8 @@ export class Guild<IsPartial extends boolean = false> extends Base {
 		IsPartial,
 		GuildDefaultMessageNotifications
 	> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.default_message_notifications
+		if (!this._rawData) return undefined as never
+		return this._rawData.default_message_notifications
 	}
 
 	/**
@@ -237,88 +241,88 @@ export class Guild<IsPartial extends boolean = false> extends Base {
 		IsPartial,
 		GuildExplicitContentFilter
 	> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.explicit_content_filter
+		if (!this._rawData) return undefined as never
+		return this._rawData.explicit_content_filter
 	}
 
 	/**
 	 * Custom guild emojis
 	 */
 	get emojis(): IfPartial<IsPartial, APIEmoji[]> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.emojis
+		if (!this._rawData) return undefined as never
+		return this._rawData.emojis
 	}
 
 	/**
 	 * Enabled guild features
 	 */
 	get features(): IfPartial<IsPartial, GuildFeature[]> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.features
+		if (!this._rawData) return undefined as never
+		return this._rawData.features
 	}
 
 	/**
 	 * Required MFA level for the guild
 	 */
 	get mfaLevel(): IfPartial<IsPartial, GuildMFALevel> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.mfa_level
+		if (!this._rawData) return undefined as never
+		return this._rawData.mfa_level
 	}
 
 	/**
 	 * Application id of the guild creator if it is bot-created
 	 */
 	get applicationId(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.application_id
+		if (!this._rawData) return undefined as never
+		return this._rawData.application_id
 	}
 
 	/**
 	 * The id of the channel where guild notices such as welcome messages and boost events are posted
 	 */
 	get systemChannelId(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.system_channel_id
+		if (!this._rawData) return undefined as never
+		return this._rawData.system_channel_id
 	}
 
 	/**
 	 * System channel flags
 	 */
 	get systemChannelFlags(): IfPartial<IsPartial, GuildSystemChannelFlags> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.system_channel_flags
+		if (!this._rawData) return undefined as never
+		return this._rawData.system_channel_flags
 	}
 
 	/**
 	 * The id of the channel where Community guilds can display rules and/or guidelines
 	 */
 	get rulesChannelId(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.rules_channel_id
+		if (!this._rawData) return undefined as never
+		return this._rawData.rules_channel_id
 	}
 
 	/**
 	 * The maximum number of presences for the guild (`null` is always returned, apart from the largest of guilds)
 	 */
 	get maxPresences(): IfPartial<IsPartial, number | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.max_presences ?? null
+		if (!this._rawData) return undefined as never
+		return this._rawData.max_presences ?? null
 	}
 
 	/**
 	 * The maximum number of members for the guild
 	 */
 	get maxMembers(): IfPartial<IsPartial, number> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.max_members ?? 0
+		if (!this._rawData) return undefined as never
+		return this._rawData.max_members ?? 0
 	}
 
 	/**
 	 * The vanity url code for the guild
 	 */
 	get vanityUrlCode(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.vanity_url_code
+		if (!this._rawData) return undefined as never
+		return this._rawData.vanity_url_code
 	}
 
 	/**
@@ -326,15 +330,15 @@ export class Guild<IsPartial extends boolean = false> extends Base {
 	 * You can use {@link Guild.bannerUrl} to get the URL of the banner.
 	 */
 	get banner(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.banner
+		if (!this._rawData) return undefined as never
+		return this._rawData.banner
 	}
 
 	/**
 	 * Get the URL of the guild's banner
 	 */
 	get bannerUrl(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
+		if (!this._rawData) return undefined as never
 		if (!this.banner) return null
 		return `https://cdn.discordapp.com/banners/${this.id}/${this.banner}.png`
 	}
@@ -343,112 +347,112 @@ export class Guild<IsPartial extends boolean = false> extends Base {
 	 * Premium tier (Server Boost level)
 	 */
 	get premiumTier(): IfPartial<IsPartial, GuildPremiumTier> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.premium_tier
+		if (!this._rawData) return undefined as never
+		return this._rawData.premium_tier
 	}
 
 	/**
 	 * The number of boosts this guild currently has
 	 */
 	get premiumSubscriptionCount(): IfPartial<IsPartial, number> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.premium_subscription_count ?? 0
+		if (!this._rawData) return undefined as never
+		return this._rawData.premium_subscription_count ?? 0
 	}
 
 	/**
 	 * The id of the channel where admins and moderators of Community guilds receive notices from Discord
 	 */
 	get publicUpdatesChannelId(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.public_updates_channel_id
+		if (!this._rawData) return undefined as never
+		return this._rawData.public_updates_channel_id
 	}
 
 	/**
 	 * The maximum amount of users in a video channel
 	 */
 	get maxVideoChannelUsers(): IfPartial<IsPartial, number> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.max_video_channel_users ?? 0
+		if (!this._rawData) return undefined as never
+		return this._rawData.max_video_channel_users ?? 0
 	}
 
 	/**
 	 * The maximum amount of users in a stage video channel
 	 */
 	get maxStageVideoChannelUsers(): IfPartial<IsPartial, number> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.max_stage_video_channel_users ?? 0
+		if (!this._rawData) return undefined as never
+		return this._rawData.max_stage_video_channel_users ?? 0
 	}
 
 	/**
 	 * Approximate number of members in this guild
 	 */
 	get approximateMemberCount(): IfPartial<IsPartial, number> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.approximate_member_count ?? 0
+		if (!this._rawData) return undefined as never
+		return this._rawData.approximate_member_count ?? 0
 	}
 
 	/**
 	 * Approximate number of non-offline members in this guild
 	 */
 	get approximatePresenceCount(): IfPartial<IsPartial, number> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.approximate_presence_count ?? 0
+		if (!this._rawData) return undefined as never
+		return this._rawData.approximate_presence_count ?? 0
 	}
 
 	/**
 	 * The welcome screen of a Community guild, shown to new members
 	 */
 	get welcomeScreen(): IfPartial<IsPartial, APIGuildWelcomeScreen | undefined> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.welcome_screen
+		if (!this._rawData) return undefined as never
+		return this._rawData.welcome_screen
 	}
 
 	/**
 	 * The nsfw level of the guild
 	 */
 	get nsfwLevel(): IfPartial<IsPartial, GuildNSFWLevel> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.nsfw_level
+		if (!this._rawData) return undefined as never
+		return this._rawData.nsfw_level
 	}
 
 	/**
 	 * Custom guild stickers
 	 */
 	get stickers(): IfPartial<IsPartial, APISticker[]> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.stickers
+		if (!this._rawData) return undefined as never
+		return this._rawData.stickers
 	}
 
 	/**
 	 * Whether the guild has the boost progress bar enabled
 	 */
 	get premiumProgressBarEnabled(): IfPartial<IsPartial, boolean> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.premium_progress_bar_enabled
+		if (!this._rawData) return undefined as never
+		return this._rawData.premium_progress_bar_enabled
 	}
 
 	/**
 	 * The type of Student Hub the guild is
 	 */
 	get hubType(): IfPartial<IsPartial, GuildHubType | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.hub_type
+		if (!this._rawData) return undefined as never
+		return this._rawData.hub_type
 	}
 
 	/**
 	 * The id of the channel where admins and moderators of Community guilds receive safety alerts from Discord
 	 */
 	get safetyAlertsChannelId(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.safety_alerts_channel_id
+		if (!this._rawData) return undefined as never
+		return this._rawData.safety_alerts_channel_id
 	}
 
 	/**
 	 * The incidents data for this guild
 	 */
 	get incidentsData(): IfPartial<IsPartial, APIIncidentsData | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.incidents_data
+		if (!this._rawData) return undefined as never
+		return this._rawData.incidents_data
 	}
 
 	/**

--- a/packages/carbon/src/structures/GuildMember.ts
+++ b/packages/carbon/src/structures/GuildMember.ts
@@ -31,8 +31,9 @@ export class GuildMember<
 
 	protected _rawData: APIGuildMember | null = null
 	get rawData(): Readonly<APIGuildMember> {
-		if (!this._rawData) throw new Error("Cannot get data without having data... smh")
-		return this._rawData;
+		if (!this._rawData)
+			throw new Error("Cannot get data without having data... smh")
+		return this._rawData
 	}
 	private setData(data: typeof this._rawData) {
 		if (!data) throw new Error("Cannot set data without having data... smh")

--- a/packages/carbon/src/structures/GuildMember.ts
+++ b/packages/carbon/src/structures/GuildMember.ts
@@ -23,21 +23,25 @@ export class GuildMember<
 		guild: Guild<IsGuildPartial>
 	) {
 		super(client)
-		this.rawData = rawData
+		this._rawData = rawData
 		this.guild = guild
 		this.user = new User(client, rawData.user)
 		this.setData(rawData)
 	}
 
-	protected rawData: APIGuildMember | null = null
-	private setData(data: typeof this.rawData) {
+	protected _rawData: APIGuildMember | null = null
+	get rawData(): Readonly<APIGuildMember> {
+		if (!this._rawData) throw new Error("Cannot get data without having data... smh")
+		return this._rawData;
+	}
+	private setData(data: typeof this._rawData) {
 		if (!data) throw new Error("Cannot set data without having data... smh")
-		this.rawData = data
+		this._rawData = data
 	}
 	private setField(key: keyof APIGuildMember, value: unknown) {
-		if (!this.rawData)
+		if (!this._rawData)
 			throw new Error("Cannot set field without having data... smh")
-		Reflect.set(this.rawData, key, value)
+		Reflect.set(this._rawData, key, value)
 	}
 
 	/**
@@ -54,8 +58,8 @@ export class GuildMember<
 	 * The guild-specific nickname of the member.
 	 */
 	get nickname(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.nick ?? null
+		if (!this._rawData) return undefined as never
+		return this._rawData.nick ?? null
 	}
 
 	/**
@@ -63,15 +67,15 @@ export class GuildMember<
 	 * You can use {@link GuildMember.avatarUrl} to get the URL of the avatar.
 	 */
 	get avatar(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.avatar ?? null
+		if (!this._rawData) return undefined as never
+		return this._rawData.avatar ?? null
 	}
 
 	/**
 	 * Get the URL of the member's guild-specific avatar
 	 */
 	get avatarUrl(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
+		if (!this._rawData) return undefined as never
 		if (!this.user || !this.avatar) return null
 		return `https://cdn.discordapp.com/guilds/${this.guild.id}/users/${this.user.id}/${this.avatar}.png`
 	}
@@ -80,24 +84,24 @@ export class GuildMember<
 	 * Is this member muted in Voice Channels?
 	 */
 	get mute(): IfPartial<IsPartial, boolean> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.mute
+		if (!this._rawData) return undefined as never
+		return this._rawData.mute
 	}
 
 	/**
 	 * Is this member deafened in Voice Channels?
 	 */
 	get deaf(): IfPartial<IsPartial, boolean> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.deaf
+		if (!this._rawData) return undefined as never
+		return this._rawData.deaf
 	}
 
 	/**
 	 * The date since this member boosted the guild, if applicable.
 	 */
 	get premiumSince(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.premium_since ?? null
+		if (!this._rawData) return undefined as never
+		return this._rawData.premium_since ?? null
 	}
 
 	/**
@@ -105,16 +109,16 @@ export class GuildMember<
 	 * @see https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-flags
 	 */
 	get flags(): IfPartial<IsPartial, GuildMemberFlags> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.flags
+		if (!this._rawData) return undefined as never
+		return this._rawData.flags
 	}
 
 	/**
 	 * The roles of the member
 	 */
 	get roles(): IfPartial<IsPartial, Role<true>[]> {
-		if (!this.rawData) return undefined as never
-		const roles = this.rawData.roles ?? []
+		if (!this._rawData) return undefined as never
+		const roles = this._rawData.roles ?? []
 		return roles.map((role) => new Role<true>(this.client, role))
 	}
 
@@ -122,24 +126,24 @@ export class GuildMember<
 	 * The joined date of the member
 	 */
 	get joinedAt(): IfPartial<IsPartial, string> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.joined_at
+		if (!this._rawData) return undefined as never
+		return this._rawData.joined_at
 	}
 
 	/**
 	 * The date when the member's communication privileges (timeout) will be reinstated
 	 */
 	get communicationDisabledUntil(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.communication_disabled_until ?? null
+		if (!this._rawData) return undefined as never
+		return this._rawData.communication_disabled_until ?? null
 	}
 
 	/**
 	 * Is this member yet to pass the guild's Membership Screening requirements?
 	 */
 	get pending(): IfPartial<IsPartial, boolean> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.pending ?? false
+		if (!this._rawData) return undefined as never
+		return this._rawData.pending ?? false
 	}
 
 	async getVoiceState(): Promise<VoiceState | null> {
@@ -187,7 +191,7 @@ export class GuildMember<
 	}
 
 	async getPermissions(): Promise<IfPartial<IsPartial, bigint[]>> {
-		if (!this.rawData) return undefined as never
+		if (!this._rawData) return undefined as never
 		if (this.guild.ownerId === this.user.id) return maxPermissions
 
 		// Check cache if client has caching enabled

--- a/packages/carbon/src/structures/Message.ts
+++ b/packages/carbon/src/structures/Message.ts
@@ -52,9 +52,13 @@ export class Message<IsPartial extends boolean = false> extends Base {
 		}
 	}
 
-	protected rawData: APIMessage | null = null
-	private setData(data: typeof this.rawData) {
-		this.rawData = data
+	protected _rawData: APIMessage | null = null
+	get rawData(): Readonly<APIMessage> {
+		if (!this._rawData) throw new Error("Cannot get data without having data... smh")
+		return this._rawData;
+	}
+	private setData(data: typeof this._rawData) {
+		this._rawData = data
 		if (!data) throw new Error("Cannot set data without having data... smh")
 	}
 
@@ -73,23 +77,23 @@ export class Message<IsPartial extends boolean = false> extends Base {
 	 * If this is true, you should use {@link Message.fetch} to get the full data of the message.
 	 */
 	get partial(): IsPartial {
-		return (this.rawData === null) as never
+		return (this._rawData === null) as never
 	}
 
 	/**
 	 * If this message is a response to an interaction, this is the ID of the interaction's application
 	 */
 	get applicationId(): IfPartial<IsPartial, string | undefined> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.application_id
+		if (!this._rawData) return undefined as never
+		return this._rawData.application_id
 	}
 
 	/**
 	 * The attachments of the message
 	 */
 	get attachments(): IfPartial<IsPartial, APIAttachment[]> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.attachments ?? []
+		if (!this._rawData) return undefined as never
+		return this._rawData.attachments ?? []
 	}
 
 	/**
@@ -99,38 +103,38 @@ export class Message<IsPartial extends boolean = false> extends Base {
 		IsPartial,
 		NonNullable<APIMessage["components"]>
 	> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.components ?? []
+		if (!this._rawData) return undefined as never
+		return this._rawData.components ?? []
 	}
 
 	/**
 	 * The content of the message
 	 */
 	get content(): IfPartial<IsPartial, string> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.content ?? ""
+		if (!this._rawData) return undefined as never
+		return this._rawData.content ?? ""
 	}
 
 	get embeds(): IfPartial<IsPartial, Embed[]> {
-		if (!this.rawData) return undefined as never
-		if (!this.rawData?.embeds) return []
-		return this.rawData.embeds.map((embed) => new Embed(embed))
+		if (!this._rawData) return undefined as never
+		if (!this._rawData?.embeds) return []
+		return this._rawData.embeds.map((embed) => new Embed(embed))
 	}
 
 	/**
 	 * If this message was edited, this is the timestamp of the edit
 	 */
 	get editedTimestamp(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.edited_timestamp as never
+		if (!this._rawData) return undefined as never
+		return this._rawData.edited_timestamp as never
 	}
 
 	/**
 	 * The flags of the message
 	 */
 	get flags(): IfPartial<IsPartial, MessageFlags> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.flags as never
+		if (!this._rawData) return undefined as never
+		return this._rawData.flags as never
 	}
 
 	/**
@@ -140,25 +144,25 @@ export class Message<IsPartial extends boolean = false> extends Base {
 		IsPartial,
 		APIMessageInteractionMetadata | undefined
 	> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.interaction_metadata
+		if (!this._rawData) return undefined as never
+		return this._rawData.interaction_metadata
 	}
 
 	/**
 	 * Whether the message mentions everyone
 	 */
 	get mentionedEveryone(): IfPartial<IsPartial, boolean> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.mention_everyone
+		if (!this._rawData) return undefined as never
+		return this._rawData.mention_everyone
 	}
 
 	/**
 	 * The users mentioned in the message
 	 */
 	get mentionedUsers(): IfPartial<IsPartial, User[]> {
-		if (!this.rawData) return undefined as never
-		if (!this.rawData?.mentions) return []
-		return this.rawData.mentions.map(
+		if (!this._rawData) return undefined as never
+		if (!this._rawData?.mentions) return []
+		return this._rawData.mentions.map(
 			(mention) => new User(this.client, mention)
 		)
 	}
@@ -167,9 +171,9 @@ export class Message<IsPartial extends boolean = false> extends Base {
 	 * The roles mentioned in the message
 	 */
 	get mentionedRoles(): IfPartial<IsPartial, Role<true>[]> {
-		if (!this.rawData) return undefined as never
-		if (!this.rawData?.mention_roles) return []
-		return this.rawData.mention_roles.map(
+		if (!this._rawData) return undefined as never
+		if (!this._rawData?.mention_roles) return []
+		return this._rawData.mention_roles.map(
 			(mention) => new Role<true>(this.client, mention)
 		)
 	}
@@ -181,35 +185,35 @@ export class Message<IsPartial extends boolean = false> extends Base {
 		IsPartial,
 		APIMessageReference | undefined
 	> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.message_reference
+		if (!this._rawData) return undefined as never
+		return this._rawData.message_reference
 	}
 
 	/**
 	 * The referenced message itself
 	 */
 	get referencedMessage(): IfPartial<IsPartial, Message | null> {
-		if (!this.rawData?.referenced_message) return null as never
-		return new Message(this.client, this.rawData?.referenced_message)
+		if (!this._rawData?.referenced_message) return null as never
+		return new Message(this.client, this._rawData?.referenced_message)
 	}
 
 	/**
 	 * Whether the message is pinned
 	 */
 	get pinned(): IfPartial<IsPartial, boolean> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.pinned
+		if (!this._rawData) return undefined as never
+		return this._rawData.pinned
 	}
 
 	/**
 	 * The poll contained in the message
 	 */
 	get poll(): IfPartial<IsPartial, Poll | undefined> {
-		if (!this.rawData?.poll) return undefined as never
+		if (!this._rawData?.poll) return undefined as never
 		return new Poll(this.client, {
 			channelId: this.channelId,
 			messageId: this.id,
-			data: this.rawData.poll
+			data: this._rawData.poll
 		})
 	}
 
@@ -217,57 +221,57 @@ export class Message<IsPartial extends boolean = false> extends Base {
 	 * The approximate position of the message in the channel
 	 */
 	get position(): IfPartial<IsPartial, number | undefined> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.position
+		if (!this._rawData) return undefined as never
+		return this._rawData.position
 	}
 
 	/**
 	 * The reactions on the message
 	 */
 	get reactions(): IfPartial<IsPartial, APIReaction[]> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.reactions ?? []
+		if (!this._rawData) return undefined as never
+		return this._rawData.reactions ?? []
 	}
 
 	/**
 	 * The stickers in the message
 	 */
 	get stickers(): IfPartial<IsPartial, APIStickerItem[]> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.sticker_items ?? []
+		if (!this._rawData) return undefined as never
+		return this._rawData.sticker_items ?? []
 	}
 
 	/**
 	 * The timestamp of the original message
 	 */
 	get timestamp(): IfPartial<IsPartial, string> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.timestamp
+		if (!this._rawData) return undefined as never
+		return this._rawData.timestamp
 	}
 
 	/**
 	 * Whether the message is a TTS message
 	 */
 	get tts(): IfPartial<IsPartial, boolean> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.tts
+		if (!this._rawData) return undefined as never
+		return this._rawData.tts
 	}
 
 	/**
 	 * The type of the message
 	 */
 	get type(): IfPartial<IsPartial, MessageType> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.type
+		if (!this._rawData) return undefined as never
+		return this._rawData.type
 	}
 
 	/**
 	 * Get the author of the message
 	 */
 	get author(): IfPartial<IsPartial, User | null> {
-		if (!this.rawData) return null as never
-		if (this.rawData?.webhook_id) return null as never // TODO: Add webhook user
-		return new User(this.client, this.rawData.author)
+		if (!this._rawData) return null as never
+		if (this._rawData?.webhook_id) return null as never // TODO: Add webhook user
+		return new User(this.client, this._rawData.author)
 	}
 
 	/**
@@ -279,11 +283,11 @@ export class Message<IsPartial extends boolean = false> extends Base {
 			ChannelType.PublicThread | ChannelType.AnnouncementThread
 		> | null
 	> {
-		if (!this.rawData) return null as never
-		if (!this.rawData?.thread) return null
+		if (!this._rawData) return null as never
+		if (!this._rawData?.thread) return null
 		return channelFactory(
 			this.client,
-			this.rawData?.thread
+			this._rawData?.thread
 		) as GuildThreadChannel<
 			ChannelType.PublicThread | ChannelType.AnnouncementThread
 		>
@@ -478,15 +482,15 @@ export class Message<IsPartial extends boolean = false> extends Base {
 	 * Disable all buttons on the message except for link buttons
 	 */
 	async disableAllButtons() {
-		if (!this.rawData) return
-		if (!this.rawData.components) return
+		if (!this._rawData) return
+		if (!this._rawData.components) return
 		const patched = (await this.client.rest.patch(
 			Routes.channelMessage(this.channelId, this.id),
 			{
 				body: {
-					...this.rawData,
+					...this._rawData,
 					components:
-						this.rawData.components?.map((component) => {
+						this._rawData.components?.map((component) => {
 							const disable = (component: APIComponentInContainer) => {
 								if (component.type === ComponentType.ActionRow) {
 									return {

--- a/packages/carbon/src/structures/Message.ts
+++ b/packages/carbon/src/structures/Message.ts
@@ -54,8 +54,9 @@ export class Message<IsPartial extends boolean = false> extends Base {
 
 	protected _rawData: APIMessage | null = null
 	get rawData(): Readonly<APIMessage> {
-		if (!this._rawData) throw new Error("Cannot get data without having data... smh")
-		return this._rawData;
+		if (!this._rawData)
+			throw new Error("Cannot get data without having data... smh")
+		return this._rawData
 	}
 	private setData(data: typeof this._rawData) {
 		this._rawData = data

--- a/packages/carbon/src/structures/Poll.ts
+++ b/packages/carbon/src/structures/Poll.ts
@@ -30,8 +30,9 @@ export class Poll extends Base {
 	}
 
 	get rawData(): Readonly<APIPoll> {
-		if (!this._rawData) throw new Error("Cannot get data without having data... smh")
-		return this._rawData;
+		if (!this._rawData)
+			throw new Error("Cannot get data without having data... smh")
+		return this._rawData
 	}
 
 	get question() {

--- a/packages/carbon/src/structures/Poll.ts
+++ b/packages/carbon/src/structures/Poll.ts
@@ -13,7 +13,7 @@ import { User } from "./User.js"
 export class Poll extends Base {
 	private channelId: string
 	private messageId: string
-	protected rawData: APIPoll
+	protected _rawData: APIPoll
 
 	constructor(
 		client: Client,
@@ -26,35 +26,40 @@ export class Poll extends Base {
 		super(client)
 		this.channelId = channelId
 		this.messageId = messageId
-		this.rawData = data
+		this._rawData = data
+	}
+
+	get rawData(): Readonly<APIPoll> {
+		if (!this._rawData) throw new Error("Cannot get data without having data... smh")
+		return this._rawData;
 	}
 
 	get question() {
-		return this.rawData.question
+		return this._rawData.question
 	}
 
 	get answers(): ReadonlyArray<APIPollAnswer> {
-		return this.rawData.answers
+		return this._rawData.answers
 	}
 
 	get allowMultiselect(): boolean {
-		return this.rawData.allow_multiselect
+		return this._rawData.allow_multiselect
 	}
 
 	get layoutType(): APIPoll["layout_type"] {
-		return this.rawData.layout_type
+		return this._rawData.layout_type
 	}
 
 	get results(): APIPoll["results"] | undefined {
-		return this.rawData.results
+		return this._rawData.results
 	}
 
 	get expiry(): string {
-		return this.rawData.expiry
+		return this._rawData.expiry
 	}
 
 	get isFinalized(): boolean {
-		return this.rawData.results !== undefined
+		return this._rawData.results !== undefined
 	}
 
 	async getAnswerVoters(answerId: number): Promise<User[]> {

--- a/packages/carbon/src/structures/Role.ts
+++ b/packages/carbon/src/structures/Role.ts
@@ -25,8 +25,9 @@ export class Role<IsPartial extends boolean = false> extends Base {
 
 	protected _rawData: APIRole | null = null
 	get rawData(): Readonly<APIRole> {
-		if (!this._rawData) throw new Error("Cannot get data without having data... smh")
-		return this._rawData;
+		if (!this._rawData)
+			throw new Error("Cannot get data without having data... smh")
+		return this._rawData
 	}
 	private setData(data: typeof this._rawData) {
 		if (!data) throw new Error("Cannot set data without having data... smh")

--- a/packages/carbon/src/structures/Role.ts
+++ b/packages/carbon/src/structures/Role.ts
@@ -17,21 +17,25 @@ export class Role<IsPartial extends boolean = false> extends Base {
 		if (typeof rawDataOrId === "string") {
 			this.id = rawDataOrId
 		} else {
-			this.rawData = rawDataOrId
+			this._rawData = rawDataOrId
 			this.id = rawDataOrId.id
 			this.setData(rawDataOrId)
 		}
 	}
 
-	protected rawData: APIRole | null = null
-	private setData(data: typeof this.rawData) {
+	protected _rawData: APIRole | null = null
+	get rawData(): Readonly<APIRole> {
+		if (!this._rawData) throw new Error("Cannot get data without having data... smh")
+		return this._rawData;
+	}
+	private setData(data: typeof this._rawData) {
 		if (!data) throw new Error("Cannot set data without having data... smh")
-		this.rawData = data
+		this._rawData = data
 	}
 	private setField(key: keyof APIRole, value: unknown) {
-		if (!this.rawData)
+		if (!this._rawData)
 			throw new Error("Cannot set field without having data... smh")
-		Reflect.set(this.rawData, key, value)
+		Reflect.set(this._rawData, key, value)
 	}
 
 	/**
@@ -44,23 +48,23 @@ export class Role<IsPartial extends boolean = false> extends Base {
 	 * If this is true, you should use {@link Role.fetch} to get the full data of the role.
 	 */
 	get partial(): IsPartial {
-		return (this.rawData === null) as never
+		return (this._rawData === null) as never
 	}
 
 	/**
 	 * The name of the role.
 	 */
 	get name(): IfPartial<IsPartial, string> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.name
+		if (!this._rawData) return undefined as never
+		return this._rawData.name
 	}
 
 	/**
 	 * The color of the role.
 	 */
 	get color(): IfPartial<IsPartial, number> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.color
+		if (!this._rawData) return undefined as never
+		return this._rawData.color
 	}
 
 	/**
@@ -68,15 +72,15 @@ export class Role<IsPartial extends boolean = false> extends Base {
 	 * You can use {@link Role.iconUrl} to get the URL of the icon.
 	 */
 	get icon(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.icon ?? null
+		if (!this._rawData) return undefined as never
+		return this._rawData.icon ?? null
 	}
 
 	/**
 	 * Get the URL of the role's icon
 	 */
 	get iconUrl(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
+		if (!this._rawData) return undefined as never
 		if (!this.icon) return null as never
 		return `https://cdn.discordapp.com/role-icons/${this.id}/${this.icon}.png`
 	}
@@ -85,48 +89,48 @@ export class Role<IsPartial extends boolean = false> extends Base {
 	 * If this role is mentionable.
 	 */
 	get mentionable(): IfPartial<IsPartial, boolean> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.mentionable
+		if (!this._rawData) return undefined as never
+		return this._rawData.mentionable
 	}
 
 	/**
 	 * If this role is hoisted.
 	 */
 	get hoisted(): IfPartial<IsPartial, boolean> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.hoist
+		if (!this._rawData) return undefined as never
+		return this._rawData.hoist
 	}
 
 	/**
 	 * The position of the role.
 	 */
 	get position(): IfPartial<IsPartial, number> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.position
+		if (!this._rawData) return undefined as never
+		return this._rawData.position
 	}
 
 	/**
 	 * The permissions of the role.
 	 */
 	get permissions(): IfPartial<IsPartial, bigint> {
-		if (!this.rawData) return undefined as never
-		return BigInt(this.rawData.permissions)
+		if (!this._rawData) return undefined as never
+		return BigInt(this._rawData.permissions)
 	}
 
 	/**
 	 * If this role is managed by an integration.
 	 */
 	get managed(): IfPartial<IsPartial, boolean> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.managed
+		if (!this._rawData) return undefined as never
+		return this._rawData.managed
 	}
 
 	/**
 	 * The unicode emoji for the role.
 	 */
 	get unicodeEmoji(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.unicode_emoji ?? null
+		if (!this._rawData) return undefined as never
+		return this._rawData.unicode_emoji ?? null
 	}
 
 	/**
@@ -134,8 +138,8 @@ export class Role<IsPartial extends boolean = false> extends Base {
 	 * @see https://discord.com/developers/docs/topics/permissions#role-object-role-flags
 	 */
 	get flags(): IfPartial<IsPartial, RoleFlags> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.flags
+		if (!this._rawData) return undefined as never
+		return this._rawData.flags
 	}
 
 	/**
@@ -143,8 +147,8 @@ export class Role<IsPartial extends boolean = false> extends Base {
 	 * @see https://discord.com/developers/docs/topics/permissions#role-object-role-tags-structure
 	 */
 	get tags(): IfPartial<IsPartial, APIRoleTags | undefined> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.tags
+		if (!this._rawData) return undefined as never
+		return this._rawData.tags
 	}
 
 	/**

--- a/packages/carbon/src/structures/ThreadMember.ts
+++ b/packages/carbon/src/structures/ThreadMember.ts
@@ -15,8 +15,9 @@ export class ThreadMember extends Base {
 
 	protected _rawData: APIThreadMember | null = null
 	get rawData(): Readonly<APIThreadMember> {
-		if (!this._rawData) throw new Error("Cannot get data without having data... smh")
-		return this._rawData;
+		if (!this._rawData)
+			throw new Error("Cannot get data without having data... smh")
+		return this._rawData
 	}
 	private setData(data: typeof this._rawData) {
 		if (!data) throw new Error("Cannot set data without having data... smh")

--- a/packages/carbon/src/structures/ThreadMember.ts
+++ b/packages/carbon/src/structures/ThreadMember.ts
@@ -8,15 +8,19 @@ import { User } from "./User.js"
 export class ThreadMember extends Base {
 	constructor(client: Client, rawData: APIThreadMember, guildId?: string) {
 		super(client)
-		this.rawData = rawData
+		this._rawData = rawData
 		this.setData(rawData)
 		this.guildId = guildId
 	}
 
-	protected rawData: APIThreadMember | null = null
-	private setData(data: typeof this.rawData) {
+	protected _rawData: APIThreadMember | null = null
+	get rawData(): Readonly<APIThreadMember> {
+		if (!this._rawData) throw new Error("Cannot get data without having data... smh")
+		return this._rawData;
+	}
+	private setData(data: typeof this._rawData) {
 		if (!data) throw new Error("Cannot set data without having data... smh")
-		this.rawData = data
+		this._rawData = data
 	}
 
 	/**
@@ -28,15 +32,15 @@ export class ThreadMember extends Base {
 	 * The ID of the thread
 	 */
 	get id(): string | undefined {
-		if (!this.rawData) return undefined as never
-		return this.rawData.id
+		if (!this._rawData) return undefined as never
+		return this._rawData.id
 	}
 	/**
 	 * The ID of the user
 	 */
 	get userId(): string | undefined {
-		if (!this.rawData) return undefined as never
-		return this.rawData.user_id
+		if (!this._rawData) return undefined as never
+		return this._rawData.user_id
 	}
 	get user(): User<true> | undefined {
 		if (!this.userId) return undefined
@@ -46,28 +50,28 @@ export class ThreadMember extends Base {
 	 * The timestamp of when the user last joined the thread
 	 */
 	get joinTimestamp(): string {
-		if (!this.rawData) return undefined as never
-		return this.rawData.join_timestamp
+		if (!this._rawData) return undefined as never
+		return this._rawData.join_timestamp
 	}
 	/**
 	 * 	Any user-thread settings, currently only used for notifications
 	 */
 	get flags(): ThreadMemberFlags {
-		if (!this.rawData) return undefined as never
-		return this.rawData.flags
+		if (!this._rawData) return undefined as never
+		return this._rawData.flags
 	}
 	/**
 	 * The member object of the user
 	 */
 	member(guildId?: string): GuildMember<false, true> | undefined {
-		if (!this.rawData?.member || !this.user) return undefined
+		if (!this._rawData?.member || !this.user) return undefined
 		// biome-ignore lint/style/noParameterAssign:
 		guildId = guildId ?? this.guildId
 		if (!guildId)
 			throw new Error("Cannot create GuildMember without a guild ID")
 		return new GuildMember<false, true>(
 			this.client,
-			this.rawData.member,
+			this._rawData.member,
 			new Guild<true>(this.client, guildId)
 		)
 	}

--- a/packages/carbon/src/structures/User.ts
+++ b/packages/carbon/src/structures/User.ts
@@ -21,20 +21,24 @@ export class User<IsPartial extends boolean = false> extends Base {
 		if (typeof rawDataOrId === "string") {
 			this.id = rawDataOrId
 		} else {
-			this.rawData = rawDataOrId
+			this._rawData = rawDataOrId
 			this.id = rawDataOrId.id
 			this.setData(rawDataOrId)
 		}
 	}
 
-	protected rawData: APIUser | null = null
-	private setData(data: typeof this.rawData) {
+	protected _rawData: APIUser | null = null
+	get rawData(): Readonly<APIUser> {
+		if (!this._rawData) throw new Error("Cannot get data without having data... smh")
+		return this._rawData;
+	}
+	private setData(data: typeof this._rawData) {
 		if (!data) throw new Error("Cannot set data without having data... smh")
-		this.rawData = data
+		this._rawData = data
 	}
 	// private setField(key: keyof APIUser, value: unknown) {
-	// 	if (!this.rawData) throw new Error("Cannot set field without having data... smh")
-	// 	Reflect.set(this.rawData, key, value)
+	// 	if (!this._rawData) throw new Error("Cannot set field without having data... smh")
+	// 	Reflect.set(this._rawData, key, value)
 	// }
 
 	/**
@@ -47,47 +51,47 @@ export class User<IsPartial extends boolean = false> extends Base {
 	 * If this is true, you should use {@link User.fetch} to get the full data of the user.
 	 */
 	get partial(): IsPartial {
-		return (this.rawData === null) as never
+		return (this._rawData === null) as never
 	}
 
 	/**
 	 * The username of the user.
 	 */
 	get username(): IfPartial<IsPartial, string> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.username
+		if (!this._rawData) return undefined as never
+		return this._rawData.username
 	}
 
 	/**
 	 * The global name of the user.
 	 */
 	get globalName(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.global_name
+		if (!this._rawData) return undefined as never
+		return this._rawData.global_name
 	}
 
 	/**
 	 * The discriminator of the user.
 	 */
 	get discriminator(): IfPartial<IsPartial, string> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.discriminator
+		if (!this._rawData) return undefined as never
+		return this._rawData.discriminator
 	}
 
 	/**
 	 * Is this user a bot?
 	 */
 	get bot(): IfPartial<IsPartial, boolean> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.bot ?? false
+		if (!this._rawData) return undefined as never
+		return this._rawData.bot ?? false
 	}
 
 	/**
 	 * Is this user a system user?
 	 */
 	get system(): IfPartial<IsPartial, boolean> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.system ?? false
+		if (!this._rawData) return undefined as never
+		return this._rawData.system ?? false
 	}
 
 	/**
@@ -95,8 +99,8 @@ export class User<IsPartial extends boolean = false> extends Base {
 	 * @see https://discord.com/developers/docs/resources/user#user-object-user-flags
 	 */
 	get flags(): IfPartial<IsPartial, UserFlags | undefined> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.public_flags
+		if (!this._rawData) return undefined as never
+		return this._rawData.public_flags
 	}
 
 	/**
@@ -105,15 +109,15 @@ export class User<IsPartial extends boolean = false> extends Base {
 	 */
 
 	get avatar(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.avatar
+		if (!this._rawData) return undefined as never
+		return this._rawData.avatar
 	}
 
 	/**
 	 * Get the URL of the user's avatar
 	 */
 	get avatarUrl(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
+		if (!this._rawData) return undefined as never
 		if (!this.avatar) return null
 		return `https://cdn.discordapp.com/avatars/${this.id}/${this.avatar}.png`
 	}
@@ -123,15 +127,15 @@ export class User<IsPartial extends boolean = false> extends Base {
 	 * You can use {@link User.bannerUrl} to get the URL of the banner.
 	 */
 	get banner(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.banner ?? null
+		if (!this._rawData) return undefined as never
+		return this._rawData.banner ?? null
 	}
 
 	/**
 	 * Get the URL of the user's banner
 	 */
 	get bannerUrl(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
+		if (!this._rawData) return undefined as never
 		if (!this.banner) return null
 		return `https://cdn.discordapp.com/banners/${this.id}/${this.banner}.png`
 	}
@@ -140,8 +144,8 @@ export class User<IsPartial extends boolean = false> extends Base {
 	 * The accent color of the user.
 	 */
 	get accentColor(): IfPartial<IsPartial, number | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.accent_color ?? null
+		if (!this._rawData) return undefined as never
+		return this._rawData.accent_color ?? null
 	}
 
 	/**

--- a/packages/carbon/src/structures/User.ts
+++ b/packages/carbon/src/structures/User.ts
@@ -29,8 +29,9 @@ export class User<IsPartial extends boolean = false> extends Base {
 
 	protected _rawData: APIUser | null = null
 	get rawData(): Readonly<APIUser> {
-		if (!this._rawData) throw new Error("Cannot get data without having data... smh")
-		return this._rawData;
+		if (!this._rawData)
+			throw new Error("Cannot get data without having data... smh")
+		return this._rawData
 	}
 	private setData(data: typeof this._rawData) {
 		if (!data) throw new Error("Cannot set data without having data... smh")

--- a/packages/carbon/src/structures/Webhook.ts
+++ b/packages/carbon/src/structures/Webhook.ts
@@ -54,8 +54,9 @@ export class Webhook<IsPartial extends boolean = false> extends Base {
 
 	protected _rawData: APIWebhook | null = null
 	get rawData(): Readonly<APIWebhook> {
-		if (!this._rawData) throw new Error("Cannot get data without having data... smh")
-		return this._rawData;
+		if (!this._rawData)
+			throw new Error("Cannot get data without having data... smh")
+		return this._rawData
 	}
 	private setData(data: typeof this._rawData) {
 		if (!data) throw new Error("Cannot set data without having data... smh")

--- a/packages/carbon/src/structures/Webhook.ts
+++ b/packages/carbon/src/structures/Webhook.ts
@@ -52,10 +52,14 @@ export class Webhook<IsPartial extends boolean = false> extends Base {
 		}
 	}
 
-	protected rawData: APIWebhook | null = null
-	private setData(data: typeof this.rawData) {
+	protected _rawData: APIWebhook | null = null
+	get rawData(): Readonly<APIWebhook> {
+		if (!this._rawData) throw new Error("Cannot get data without having data... smh")
+		return this._rawData;
+	}
+	private setData(data: typeof this._rawData) {
 		if (!data) throw new Error("Cannot set data without having data... smh")
-		this.rawData = data
+		this._rawData = data
 	}
 
 	/**
@@ -78,7 +82,7 @@ export class Webhook<IsPartial extends boolean = false> extends Base {
 	 * If this is true, you should use {@link Webhook.fetch} to get the full data of the webhook.
 	 */
 	get partial(): IsPartial {
-		return (this.rawData === null) as never
+		return (this._rawData === null) as never
 	}
 
 	/**
@@ -86,24 +90,24 @@ export class Webhook<IsPartial extends boolean = false> extends Base {
 	 * @see https://discord.com/developers/docs/resources/webhook#webhook-object-webhook-types
 	 */
 	get type(): IfPartial<IsPartial, WebhookType> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.type
+		if (!this._rawData) return undefined as never
+		return this._rawData.type
 	}
 
 	/**
 	 * The guild id this webhook is for
 	 */
 	get guildId(): IfPartial<IsPartial, string | undefined> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.guild_id
+		if (!this._rawData) return undefined as never
+		return this._rawData.guild_id
 	}
 
 	/**
 	 * The channel id this webhook is for
 	 */
 	get channelId(): IfPartial<IsPartial, string> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.channel_id
+		if (!this._rawData) return undefined as never
+		return this._rawData.channel_id
 	}
 
 	/**
@@ -111,31 +115,31 @@ export class Webhook<IsPartial extends boolean = false> extends Base {
 	 * Not returned when getting a webhook with its token
 	 */
 	get user(): IfPartial<IsPartial, User | undefined> {
-		if (!this.rawData?.user) return undefined as never
-		return new User(this.client, this.rawData.user)
+		if (!this._rawData?.user) return undefined as never
+		return new User(this.client, this._rawData.user)
 	}
 
 	/**
 	 * The default name of the webhook
 	 */
 	get name(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.name
+		if (!this._rawData) return undefined as never
+		return this._rawData.name
 	}
 
 	/**
 	 * The default avatar of the webhook
 	 */
 	get avatar(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.avatar
+		if (!this._rawData) return undefined as never
+		return this._rawData.avatar
 	}
 
 	/**
 	 * Get the URL of the webhook's avatar
 	 */
 	get avatarUrl(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
+		if (!this._rawData) return undefined as never
 		if (!this.avatar) return null
 		return `https://cdn.discordapp.com/avatars/${this.id}/${this.avatar}.png`
 	}
@@ -144,8 +148,8 @@ export class Webhook<IsPartial extends boolean = false> extends Base {
 	 * The bot/OAuth2 application that created this webhook
 	 */
 	get applicationId(): IfPartial<IsPartial, string | null> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.application_id
+		if (!this._rawData) return undefined as never
+		return this._rawData.application_id
 	}
 
 	/**
@@ -156,8 +160,8 @@ export class Webhook<IsPartial extends boolean = false> extends Base {
 		IsPartial,
 		APIWebhook["source_guild"] | undefined
 	> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.source_guild
+		if (!this._rawData) return undefined as never
+		return this._rawData.source_guild
 	}
 
 	/**
@@ -168,8 +172,8 @@ export class Webhook<IsPartial extends boolean = false> extends Base {
 		IsPartial,
 		APIWebhook["source_channel"] | undefined
 	> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.source_channel
+		if (!this._rawData) return undefined as never
+		return this._rawData.source_channel
 	}
 
 	/**
@@ -177,8 +181,8 @@ export class Webhook<IsPartial extends boolean = false> extends Base {
 	 * Only returned by the webhooks OAuth2 flow
 	 */
 	get url(): IfPartial<IsPartial, string | undefined> {
-		if (!this.rawData) return undefined as never
-		return this.rawData.url
+		if (!this._rawData) return undefined as never
+		return this._rawData.url
 	}
 
 	/**


### PR DESCRIPTION
This is a **proof of concept** of how you should be able to get the rawData object.

I added a rawData getter method returning a readable `rawData` to every class that had `protected rawData`, besides the class `BaseChannel`.

I did this by renaming the current `rawData` variables into `_rawData`, then added a getter method called `rawData()`.

**Don't actually accept this pull request... Why?**

- I feel like the way I added the getter classes are a little hacky. There's probably a better way to do this.
- I didn't touch `BaseChannel` and all of the channel classes either, because you can already get `rawData` for most of those classes. But this makes `rawData` inconsistent, because it's `readonly` for everywhere besides channels and `BaseChannel` doesn't have a `rawData` getter method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added read-only access to raw data for Guild, GuildMember, Message, Poll, Role, ThreadMember, User, and Webhook entities, with explicit error handling if data is missing.

- **Refactor**
  - Improved internal data encapsulation and consistency across multiple entities, ensuring safer and more controlled access to underlying data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->