### PR TITLE
Fix casing in link

### DIFF
--- a/website/content/even-more/why-classes.mdx
+++ b/website/content/even-more/why-classes.mdx
@@ -101,4 +101,4 @@ Every part of Carbon is built to be extendable. Want to add something to the cli
 
 I've been using Carbon for a while now, and I've noticed that it's not perfect. We're always open to feedback and suggestions, so if you have any, please let me know! I'd love to hear about any bugs you find, or any features you'd like to see added.
 
-If you're interested in contributing to Carbon, you can check out the [Contributing Guide](/even-more/contributing) for more information, and join our [Discord](https://go.buape.com/Carbon) to get involved!
+If you're interested in contributing to Carbon, you can check out the [Contributing Guide](/even-more/contributing) for more information, and join our [Discord](https://go.buape.com/carbon) to get involved!

--- a/website/content/getting-started/introduction.mdx
+++ b/website/content/getting-started/introduction.mdx
@@ -10,7 +10,7 @@ Carbon is a powerful and versatile framework designed for building HTTP-based Di
 
 ## Join the Community
 
-Join our community on [Discord](https://go.buape.com/Carbon) to connect with fellow developers, share your projects, and get support. We look forward to seeing the innovative bots you create with Carbon!
+Join our community on [Discord](https://go.buape.com/carbon) to connect with fellow developers, share your projects, and get support. We look forward to seeing the innovative bots you create with Carbon!
 
 <span className="dark:hidden">
 [![Discord Invite](https://invidget.switchblade.xyz/rT8vZAmVaQ?theme=light)](https://go.buape.com/carbon)

--- a/website/content/plugins/gateway.mdx
+++ b/website/content/plugins/gateway.mdx
@@ -106,4 +106,4 @@ Starting out with Gateway connections? Here's what you need to know: Start with 
 
 Only request the intents you actually need - this helps your bot run more efficiently and keeps Discord's servers happy. And remember that some intents (like `MessageContent`) are "privileged" and need to be enabled in your Discord application settings. Keep an eye on your connection health through events like `RESUMED`, `READY`, and `INVALID_SESSION`.
 
-Don't forget about the basics either - always use proper User-Agent headers in your requests to Discord's API, and make sure you're handling rate limits properly (though the plugins do this automatically). If you run into any issues or have questions, join our [Discord server](https://go.buape.com/Carbon) - we're always happy to help!
+Don't forget about the basics either - always use proper User-Agent headers in your requests to Discord's API, and make sure you're handling rate limits properly (though the plugins do this automatically). If you run into any issues or have questions, join our [Discord server](https://go.buape.com/carbon) - we're always happy to help!


### PR DESCRIPTION
Fun fact: this is case-sensitive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Discord invite URL from /Carbon to /carbon across Getting Started, Why Classes, and Plugins docs for consistent casing.
  * Applied link correction to light/dark inline invites and Quick Tips.
  * Minor formatting cleanup (end-of-file newline).
  * No content, logic, or behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->