### PR TITLE
feat: add support for current member set banner/avatar/bio

### DIFF
--- a/.changeset/social-bananas-grow.md
+++ b/.changeset/social-bananas-grow.md
@@ -1,0 +1,5 @@
+---
+"@buape/carbon": minor
+---
+
+feat: add support for current member set banner/avatar/bio

--- a/packages/carbon/src/structures/GuildMember.ts
+++ b/packages/carbon/src/structures/GuildMember.ts
@@ -210,6 +210,35 @@ export class GuildMember<
 	}
 
 	/**
+	 * Set the member's guild-specific data
+	 * This will only work if the current member is the bot itself, and will throw an error if it is not
+	 */
+	async setMemberData(
+		data: {
+			/**
+			 * Data URI base64 encoded banner image
+			 */
+			banner?: string | null
+			bio?: string
+			/**
+			 * Data URI base64 encoded avatar image
+			 */
+			avatar?: string | null
+		},
+		reason?: string
+	): Promise<void> {
+		await this.client.rest.patch(
+			`/guilds/${this.guild?.id}/members/${this.user?.id}`,
+			{
+				body: data,
+				headers: reason ? { "X-Audit-Log-Reason": reason } : undefined
+			}
+		)
+		if (data.banner) this.setField("banner", data.banner)
+		if (data.avatar) this.setField("avatar", data.avatar)
+	}
+
+	/**
 	 * Add a role to the member
 	 */
 	async addRole(roleId: string, reason?: string): Promise<void> {

--- a/packages/carbon/src/structures/GuildMember.ts
+++ b/packages/carbon/src/structures/GuildMember.ts
@@ -219,7 +219,7 @@ export class GuildMember<
 			 * Data URI base64 encoded banner image
 			 */
 			banner?: string | null
-			bio?: string
+			bio?: string | null
 			/**
 			 * Data URI base64 encoded avatar image
 			 */

--- a/packages/carbon/src/structures/GuildMember.ts
+++ b/packages/carbon/src/structures/GuildMember.ts
@@ -234,8 +234,8 @@ export class GuildMember<
 				headers: reason ? { "X-Audit-Log-Reason": reason } : undefined
 			}
 		)
-		if (data.banner) this.setField("banner", data.banner)
-		if (data.avatar) this.setField("avatar", data.avatar)
+		if ("banner" in data) this.setField("banner", data.banner ?? null)
+		if ("avatar" in data) this.setField("avatar", data.avatar ?? null)
 	}
 
 	/**


### PR DESCRIPTION
Closes #288 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now update the current member’s banner, avatar, and bio within a guild, with optional audit-log reasons. This operation applies to the bot’s own membership.
* **Chores**
  * Prepares a minor version release of @buape/carbon reflecting the new member profile update capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->