### PR TITLE
fix: correct typo ("achnowledging")

### DIFF
--- a/website/content/concepts/interaction-responses.mdx
+++ b/website/content/concepts/interaction-responses.mdx
@@ -1,5 +1,5 @@
 ---
-title: Replying vs Defering vs Achnowledging
+title: Replying vs Defering vs Acknowledging
 description: Understand the different ways to respond to Discord interactions, including replying, deferring, and acknowledging, and learn when to use each method.
 icon: MessageCircle
 ---


### PR DESCRIPTION
It's a header text and therefore also appears on the site's sidebar, which makes it interesting that nobody noticed this for almost a year now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the page title to “Replying vs Defering vs Acknowledging.”
  * Improves readability and professionalism on the Interaction Responses concept page.
  * Updates displayed headings and metadata for clearer navigation and search indexing.
  * No functional or behavioral changes for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->