### PR TITLE
fix: incorrect content type for commands route from command data plugin

### DIFF
--- a/.changeset/silent-ghosts-clean.md
+++ b/.changeset/silent-ghosts-clean.md
@@ -1,0 +1,5 @@
+---
+"@buape/carbon": patch
+---
+
+fix: incorrect content type for commands route from command data plugin

--- a/packages/carbon/src/plugins/command-data/CommandDataPlugin.ts
+++ b/packages/carbon/src/plugins/command-data/CommandDataPlugin.ts
@@ -33,16 +33,12 @@ export class CommandDataPlugin extends Plugin {
 	public async handleFullCommandDataRequest() {
 		if (!this.client)
 			return new Response("Client not registered", { status: 500 })
-		if (this.discordCommandData)
-			return new Response(JSON.stringify(this.discordCommandData), {
-				status: 200,
-				headers: { "Content-Type": "application/json" }
-			})
+		if (this.discordCommandData) return Response.json(this.discordCommandData)
 		const commands = (await this.client.rest.get(
 			Routes.applicationCommands(this.client.options.clientId)
 		)) as APIApplicationCommand[]
 		this.discordCommandData = commands
-		return new Response(JSON.stringify(commands), { status: 200 })
+		return Response.json(commands)
 	}
 
 	public async handleCommandDataRequest() {
@@ -51,6 +47,6 @@ export class CommandDataPlugin extends Plugin {
 		const commands = this.client?.commands
 			.filter((c) => c.name !== "*")
 			.map((c) => c.serialize())
-		return new Response(JSON.stringify(commands), { status: 200 })
+		return Response.json(commands)
 	}
 }


### PR DESCRIPTION
Routes that return json should use `Response.json` as it provides the content type header. The response headers for the `/commands` was missing the content type header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the content type for the commands endpoint to return proper JSON.
  * Standardized command data responses to JSON for consistent behavior across routes, improving client compatibility and caching.

* **Chores**
  * Added a patch release entry for @buape/carbon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->