### PR TITLE
feat: add Command#getMention method

### DIFF
--- a/packages/carbon/src/abstracts/BaseCommand.ts
+++ b/packages/carbon/src/abstracts/BaseCommand.ts
@@ -142,7 +142,7 @@ export abstract class BaseCommand {
 	 * @returns A string in the format `</name:id>` that Discord will render as a command mention
 	 * @remarks If the command ID is not set, this will fetch the commands from Discord to get the ID
 	 */
-	async getMention(client: { getDiscordCommands: () => Promise<{ id: string; name: string }[]> }): Promise<string> {
+	async getMention(client: { getDiscordCommands: () => Promise<Array<{ id: string; name: string }>> }): Promise<string> {
 		if (!this.id) {
 			const commands = await client.getDiscordCommands()
 			const command = commands.find((c) => c.name === this.name)

--- a/packages/carbon/src/classes/Client.ts
+++ b/packages/carbon/src/classes/Client.ts
@@ -10,6 +10,7 @@ import {
 	ApplicationWebhookType,
 	InteractionResponseType,
 	InteractionType,
+	type RESTGetAPIApplicationCommandsResult,
 	Routes
 } from "discord-api-types/v10"
 import type { BaseCommand } from "../abstracts/BaseCommand.js"
@@ -277,7 +278,7 @@ export class Client {
 				const deployed = (await this.rest.put(
 					Routes.applicationGuildCommands(this.options.clientId, guildId),
 					{ body: commands.map((c) => c.serialize()) }
-				)) as { id: string; name: string }[]
+				)) as RESTGetAPIApplicationCommandsResult
 
 				// Update command IDs
 				for (const deployedCommand of deployed) {
@@ -293,7 +294,7 @@ export class Client {
 			const deployed = (await this.rest.put(
 				Routes.applicationGuildCommands(this.options.clientId, guildId),
 				{ body: cmds }
-			)) as { id: string; name: string }[]
+			)) as RESTGetAPIApplicationCommandsResult
 
 			// Update command IDs
 			for (const deployedCommand of deployed) {
@@ -307,7 +308,7 @@ export class Client {
 			const deployed = (await this.rest.put(
 				Routes.applicationCommands(this.options.clientId),
 				{ body: globalCommands.map((c) => c.serialize()) }
-			)) as { id: string; name: string }[]
+			)) as RESTGetAPIApplicationCommandsResult
 
 			// Update command IDs
 			for (const deployedCommand of deployed) {
@@ -547,7 +548,7 @@ export class Client {
 	async getDiscordCommands() {
 		return (await this.rest.get(
 			Routes.applicationCommands(this.options.clientId)
-		)) as { id: string; name: string }[]
+		)) as RESTGetAPIApplicationCommandsResult
 	}
 
 	// ======================== End Fetchers ================================================


### PR DESCRIPTION
Implements #326

Adds a `getMention()` method to the Command class that returns a Discord command mention string.

**Changes:**
- Add `id` property to BaseCommand class to store Discord command ID
- Update handleDeployRequest to store command IDs after deployment
- Add getMention() method that returns command mention string (`</name:id>`)
- Add getDiscordCommands() method to Client for fetching command IDs
- Lazy load command ID from Discord if not set during getMention call

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added command mention formatting for clearer in-app references.
  * Deployment now automatically captures and synchronizes deployed command IDs.
  * Added ability to retrieve and manage deployed commands from the Discord API for improved command management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->