### PR TITLE
fix(gateway): reset reconnect backoff on READY/RESUMED instead of ws open

### DIFF
--- a/.changeset/fix-gateway-reconnect-backoff.md
+++ b/.changeset/fix-gateway-reconnect-backoff.md
@@ -2,4 +2,4 @@
 "@buape/carbon": patch
 ---
 
-fix(gateway): reset reconnect backoff counter on READY/RESUMED instead of WebSocket open to prevent connection storms
+fix: reset reconnect backoff counter on READY/RESUMED instead of WebSocket open to prevent connection storms

--- a/packages/carbon/src/plugins/gateway/GatewayPlugin.ts
+++ b/packages/carbon/src/plugins/gateway/GatewayPlugin.ts
@@ -269,12 +269,12 @@ export class GatewayPlugin extends Plugin {
 							this.state.sessionId = readyData.session_id
 							this.state.resumeGatewayUrl = readyData.resume_gateway_url
 						}
+						if (t1 === "READY" || t1 === "RESUMED") {
+							this.isConnected = true
+							this.reconnectAttempts = 0
+						}
 						if (t && this.client) {
 							if (!this.options.eventFilter || this.options.eventFilter?.(t1)) {
-								if (t1 === "READY" || t1 === "RESUMED") {
-									this.isConnected = true
-									this.reconnectAttempts = 0
-								}
 								if (t1 === "READY") {
 									const readyData = d as ListenerEventRawData[typeof t1]
 									readyData.guilds.forEach((guild) => {


### PR DESCRIPTION
## Summary

Moves `reconnectAttempts = 0` from the WebSocket `open` handler to the `READY`/`RESUMED` dispatch handler.

When Discord opens the WebSocket but immediately closes it (code 1000) before completing the handshake, the counter resets on every open, keeping backoff at 1000ms forever instead of increasing exponentially. This can cause connection storms (~60 connections/minute) that trigger Discord to reset the bot token.

## What changed

- **Removed** `this.reconnectAttempts = 0` from `ws.on("open")`
- **Added** `this.reconnectAttempts = 0` after `this.isConnected = true` in the `READY`/`RESUMED` dispatch handler

This ensures backoff keeps increasing when connections open but fail before completing the handshake, and only resets once a session is actually established.

## Evidence

Gateway log showing backoff stuck at 1000ms for 90+ seconds:

```
05:47:20 Reconnecting with backoff: 1000ms after code 1000
05:47:21 Reconnecting with backoff: 1000ms after code 1000
05:47:22 Reconnecting with backoff: 1000ms after code 1000
  ... (repeated ~90 times until Discord reset the token)
05:48:53 Fatal Gateway error: 4004
```

Fixes #344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway reconnection backoff: the reconnect counter now resets only after a successful session handshake (READY/RESUMED), preventing premature resets and reducing connection storms.

* **Documentation**
  * Added a changelog entry documenting the patch release and the reconnection behavior adjustment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->