### PR TITLE
feat(gateway): add WebSocket agent/proxy support

### DIFF
--- a/packages/carbon/src/plugins/gateway/GatewayPlugin.ts
+++ b/packages/carbon/src/plugins/gateway/GatewayPlugin.ts
@@ -169,7 +169,8 @@ export class GatewayPlugin extends Plugin {
 		if (!url) {
 			throw new Error("Gateway URL is required")
 		}
-		return new WebSocket(url)
+		const options = this.options.agent ? { agent: this.options.agent } : undefined
+		return new WebSocket(url, options)
 	}
 
 	protected setupWebSocket(): void {

--- a/packages/carbon/src/plugins/gateway/types.ts
+++ b/packages/carbon/src/plugins/gateway/types.ts
@@ -5,6 +5,7 @@ import {
 	GatewayIntentBits,
 	type GatewayReadyDispatchData
 } from "discord-api-types/v10"
+import type { Agent } from 'http'
 import type { ListenerEventType } from "../../types/index.js"
 
 export interface GatewayPluginOptions {
@@ -48,6 +49,22 @@ export interface GatewayPluginOptions {
 	 * @default false
 	 */
 	autoInteractions?: boolean
+	/**
+	 * Optional HTTP/SOCKS agent for WebSocket connections
+	 * Useful for proxy support (e.g., SOCKS5, HTTP proxy)
+	 *
+	 * @example
+	 * ```typescript
+	 * import { SocksProxyAgent } from 'socks-proxy-agent'
+	 * const agent = new SocksProxyAgent('socks5://127.0.0.1:7898')
+	 *
+	 * new GatewayPlugin({
+	 *     intents,
+	 *     agent
+	 * })
+	 * ```
+	 */
+	agent?: Agent
 }
 
 /**


### PR DESCRIPTION
This PR adds support for custom WebSocket agents, enabling proxy usage (e.g., SOCKS5, HTTP) for Discord Gateway connections.

## Problem
Users behind corporate firewalls or in regions requiring proxy cannot connect to Discord Gateway because the WebSocket connection doesn't support proxy configuration.

## Solution
- Add optional `agent` parameter to `GatewayPluginOptions`
- Pass agent to WebSocket constructor when provided

## Usage
```typescript
import { SocksProxyAgent } from 'socks-proxy-agent'

const agent = new SocksProxyAgent('socks5://127.0.0.1:7898')

const client = new Client(
    { /* options */ },
    { /* commands */ },
    [
        new GatewayPlugin({
            intents: GatewayIntents.GuildMessages,
            agent  // Pass the agent here
        })
    ]
)
```

## Breaking Changes
None - this is a purely additive change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring HTTP/SOCKS proxy agents for gateway connections, enabling users to route WebSocket traffic through proxy servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->