### PR TITLE
fix: pin hono >=4.11.10 in optionalDependencies to resolve timing vulnerability

### DIFF
--- a/.changeset/fix-hono-security-pin.md
+++ b/.changeset/fix-hono-security-pin.md
@@ -1,0 +1,9 @@
+---
+"@buape/carbon": patch
+---
+
+The node adapter (`adapters/node`) uses `@hono/node-server`, which declares `hono` as a peer dependency (`^4`). Without a minimum version floor on `hono` itself, consumers who don't have `hono` as a direct dependency may resolve to a version below `4.11.10`, which contains a timing comparison vulnerability in `basicAuth` ([GHSA-jmr7-xgp7-cmfj](https://github.com/advisories/GHSA-jmr7-xgp7-cmfj)).
+
+`hono` is now declared as an optional dependency with `>=4.11.10` so that package managers resolve a safe version for consumers using the node adapter.
+
+If you are using the node adapter and manage `hono` explicitly in your own `package.json`, ensure it is at `>=4.11.10`.

--- a/packages/carbon/package.json
+++ b/packages/carbon/package.json
@@ -32,6 +32,7 @@
 		"@cloudflare/workers-types": "4.20260120.0",
 		"@discordjs/voice": "0.19.0",
 		"@hono/node-server": "1.19.9",
+		"hono": ">=4.11.10",
 		"@types/bun": "1.3.9",
 		"@types/ws": "8.18.1",
 		"ws": "8.19.0"


### PR DESCRIPTION
## Summary

- Adds `hono: ">=4.11.10"` to `optionalDependencies` in `packages/carbon/package.json`
- The node adapter (`src/adapters/node/index.ts`) uses `@hono/node-server`, which declares `hono` as a peer dependency (`^4`)
- Without a minimum version floor, consumers who don't have `hono` as a direct dependency may resolve to `hono <4.11.10`, which has a known timing comparison vulnerability in `basicAuth` ([GHSA-jmr7-xgp7-cmfj](https://github.com/advisories/GHSA-jmr7-xgp7-cmfj))
- Adding it as an optional dep ensures pnpm/npm/yarn resolve a safe version for consumers using the node adapter

## Test plan

- [ ] `pnpm install` succeeds with `hono >=4.11.10` resolved
- [ ] `pnpm build` passes
- [ ] `pnpm audit` no longer reports the hono timing vulnerability

🤖 Generated with [Claude Code](https://claude.com/claude-code)