### PR TITLE
feat(request): support custom fetch dispatcher without global mutation

### DIFF
--- a/packages/carbon/src/classes/RequestClient.ts
+++ b/packages/carbon/src/classes/RequestClient.ts
@@ -42,6 +42,11 @@ export type RequestClientOptions = {
 	 */
 	queueRequests?: boolean
 	/**
+	 * Optional custom dispatcher passed to fetch (Node/undici runtimes).
+	 * Useful for HTTP(S) proxying without mutating globalThis.fetch.
+	 */
+	dispatcher?: unknown
+	/**
 	 * The maximum amount of queued requests before throwing.
 	 * @default 1000
 	 */
@@ -55,6 +60,7 @@ const defaultOptions: Required<RequestClientOptions> = {
 	userAgent: "DiscordBot (https://github.com/buape/carbon, v0.0.0)",
 	timeout: 15000,
 	queueRequests: true,
+	dispatcher: undefined,
 	maxQueueSize: 1000
 }
 
@@ -314,13 +320,17 @@ export class RequestClient {
 			}, timeoutMs)
 		}
 		let response: Response
+		const requestInit: RequestInit & { dispatcher?: unknown } = {
+			method,
+			headers,
+			body,
+			signal: this.abortController.signal
+		}
+		if (this.options.dispatcher !== undefined) {
+			requestInit.dispatcher = this.options.dispatcher
+		}
 		try {
-			response = await fetch(url, {
-				method,
-				headers,
-				body,
-				signal: this.abortController.signal
-			})
+			response = await fetch(url, requestInit)
 		} finally {
 			if (timeoutId) {
 				clearTimeout(timeoutId)


### PR DESCRIPTION
## Summary\n- add optional `dispatcher` to `RequestClientOptions`\n- pass dispatcher to `fetch` request init when provided\n- avoid any `globalThis.fetch` mutation to keep concurrent requests safe\n\n## Why\nA downstream integration attempted proxy support by swapping `globalThis.fetch` around REST calls, which introduces race conditions under concurrency. This upstream change enables proxy/dispatcher injection per request client instance without global side effects.\n\n## Notes\n- backwards compatible: dispatcher is optional\n- no behavior change unless dispatcher is configured\n