### PR TITLE
Gateway: suppress reconnects on intentional close

### DIFF
--- a/packages/carbon/src/plugins/gateway/GatewayPlugin.ts
+++ b/packages/carbon/src/plugins/gateway/GatewayPlugin.ts
@@ -39,6 +39,18 @@ interface HelloData {
 	heartbeat_interval: number
 }
 
+type IntentionalCloseWebSocket = WebSocket & {
+	__carbonIntentionalClose?: boolean
+}
+
+function markIntentionalSocketClose(ws: WebSocket | null): void {
+	if (!ws) {
+		return
+	}
+
+	;(ws as IntentionalCloseWebSocket).__carbonIntentionalClose = true
+}
+
 export class GatewayPlugin extends Plugin {
 	readonly id = "gateway"
 	protected client?: Client
@@ -142,6 +154,7 @@ export class GatewayPlugin extends Plugin {
 			this.reconnectTimeout = undefined
 		}
 
+		markIntentionalSocketClose(this.ws)
 		this.ws?.close()
 
 		const baseUrl =
@@ -161,6 +174,7 @@ export class GatewayPlugin extends Plugin {
 		stopHeartbeat(this)
 		this.lastHeartbeatAck = true
 		this.monitor.resetUptime()
+		markIntentionalSocketClose(this.ws)
 		this.ws?.close()
 		this.ws = null
 		if (this.reconnectTimeout) {
@@ -191,9 +205,10 @@ export class GatewayPlugin extends Plugin {
 	protected setupWebSocket(): void {
 		if (!this.ws) return
 
+		const socket = this.ws as IntentionalCloseWebSocket
 		let closed = false
 
-		this.ws.on("open", () => {
+		socket.on("open", () => {
 			this.isConnecting = false
 			// Note: reconnectAttempts is reset on READY/RESUMED instead of here,
 			// so that exponential backoff keeps increasing when the socket opens
@@ -201,7 +216,7 @@ export class GatewayPlugin extends Plugin {
 			this.emitter.emit("debug", "WebSocket connection opened")
 		})
 
-		this.ws.on("message", (data: WebSocket.Data) => {
+		socket.on("message", (data: WebSocket.Data) => {
 			this.monitor.recordMessageReceived()
 
 			const payload = validatePayload(data.toString())
@@ -383,7 +398,7 @@ export class GatewayPlugin extends Plugin {
 			}
 		})
 
-		this.ws.on("close", (code: number, _reason: Buffer) => {
+		socket.on("close", (code: number, _reason: Buffer) => {
 			this.isConnecting = false
 			this.emitter.emit(
 				"debug",
@@ -391,13 +406,13 @@ export class GatewayPlugin extends Plugin {
 			)
 			this.monitor.recordReconnect()
 
-			if (closed) return
+			if (closed || socket.__carbonIntentionalClose) return
 			closed = true
 
 			this.handleClose(code)
 		})
 
-		this.ws.on("error", (error: Error) => {
+		socket.on("error", (error: Error) => {
 			this.isConnecting = false
 			this.monitor.recordError()
 			this.emitter.emit("error", error)

--- a/packages/carbon/tests/gateway-reconnect.test.ts
+++ b/packages/carbon/tests/gateway-reconnect.test.ts
@@ -11,6 +11,7 @@ class MockWebSocket extends EventEmitter {
 
 	close(): void {
 		this.readyState = 3
+		this.emit("close", 1005, Buffer.alloc(0))
 	}
 }
 
@@ -26,6 +27,49 @@ class TestGatewayPlugin extends GatewayPlugin {
 
 afterEach(() => {
 	vi.useRealTimers()
+})
+
+test("disconnect does not emit reconnect exhaustion for intentional close", () => {
+	const plugin = new TestGatewayPlugin({
+		intents: GatewayIntents.Guilds,
+		url: "wss://gateway.discord.gg",
+		reconnect: { maxAttempts: 0 }
+	})
+	const errorListener = vi.fn()
+	;(plugin as GatewayPlugin & { emitter: EventEmitter }).emitter.on(
+		"error",
+		errorListener
+	)
+
+	plugin.connect()
+	plugin.disconnect()
+
+	expect(errorListener).not.toHaveBeenCalled()
+})
+
+test("unexpected close still emits reconnect exhaustion when retries are disabled", () => {
+	const plugin = new TestGatewayPlugin({
+		intents: GatewayIntents.Guilds,
+		url: "wss://gateway.discord.gg",
+		reconnect: { maxAttempts: 0 }
+	})
+	const errorListener = vi.fn()
+	;(plugin as GatewayPlugin & { emitter: EventEmitter }).emitter.on(
+		"error",
+		errorListener
+	)
+
+	plugin.connect()
+	const socket = plugin.sockets[0]
+	if (!socket) {
+		throw new Error("Expected initial socket")
+	}
+
+	socket.emit("close", 1005, Buffer.alloc(0))
+
+	expect(errorListener).toHaveBeenCalledWith(
+		new Error("Max reconnect attempts (0) reached after code 1005")
+	)
 })
 
 test("does not reconnect twice when Invalid Session is followed by close", () => {


### PR DESCRIPTION
## Summary

- I fixed a gateway shutdown bug where an intentional websocket close could still flow through reconnect handling.
- I now mark closes triggered by `disconnect()` and connection replacement as intentional before closing the existing socket.
- I added gateway reconnect regressions to lock in the intentional-close case and to ensure unexpected closes still emit reconnect exhaustion when retries are disabled.

## Root Cause

`GatewayPlugin.disconnect()` and `GatewayPlugin.connect()` both closed the current websocket without tagging that close as intentional. When the socket's `close` event fired, the gateway treated it like an unexpected disconnect and could emit reconnect-exhausted errors during a clean shutdown.

## Verification

- `pnpm exec vitest run packages/carbon/tests/gateway-reconnect.test.ts packages/carbon/tests/plugins/gateway-heartbeat.test.ts`
- `pnpm lint packages/carbon/src/plugins/gateway/GatewayPlugin.ts packages/carbon/tests/gateway-reconnect.test.ts`
- `pnpm build --filter @buape/carbon`

## Manual Verification

- I verified the focused gateway tests pass locally.
- Harold also verified end to end in OpenClaw that shutdown no longer throws `Max reconnect attempts (0) reached after code 1005` on exit.
