### PR TITLE
Prefer runtime WebSocket for gateway

### DIFF
--- a/packages/carbon/src/plugins/gateway/GatewayPlugin.ts
+++ b/packages/carbon/src/plugins/gateway/GatewayPlugin.ts
@@ -219,6 +219,12 @@ export class GatewayPlugin extends Plugin {
 		const socket = this.options.webSocketFactory
 			? this.options.webSocketFactory(url)
 			: (() => {
+					if (typeof globalThis.WebSocket === "function") {
+						return new globalThis.WebSocket(
+							url
+						) as unknown as GatewayWebSocketLike
+					}
+
 					if (nodeRequire) {
 						try {
 							const wsModule = nodeRequire("ws") as {
@@ -239,14 +245,8 @@ export class GatewayPlugin extends Plugin {
 								return new nodeWebSocket(url)
 							}
 						} catch {
-							// fall through to global WebSocket
+							// fall through when ws is unavailable
 						}
-					}
-
-					if (typeof globalThis.WebSocket === "function") {
-						return new globalThis.WebSocket(
-							url
-						) as unknown as GatewayWebSocketLike
 					}
 
 					return null

--- a/packages/carbon/tests/plugins/gateway.test.ts
+++ b/packages/carbon/tests/plugins/gateway.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+import { GatewayPlugin } from "../../src/plugins/gateway/GatewayPlugin.js"
+
+class MockGlobalWebSocket {
+	readyState = 0
+	url: string
+	binaryType = "blob"
+
+	constructor(url: string) {
+		this.url = url
+	}
+
+	send() {}
+	close() {}
+	addEventListener() {}
+}
+
+describe("GatewayPlugin websocket selection", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals()
+	})
+
+	test("prefers global WebSocket over ws on Node runtimes", () => {
+		vi.stubGlobal("WebSocket", MockGlobalWebSocket)
+
+		const plugin = new GatewayPlugin({ intents: 0 })
+		const socket = (
+			plugin as unknown as {
+				createWebSocket: (url: string) => MockGlobalWebSocket
+			}
+		).createWebSocket("wss://gateway.discord.gg/?v=10&encoding=json")
+
+		expect(socket).toBeInstanceOf(MockGlobalWebSocket)
+		expect(socket.url).toBe("wss://gateway.discord.gg/?v=10&encoding=json")
+		expect(socket.binaryType).toBe("arraybuffer")
+	})
+})


### PR DESCRIPTION
# Carbon WebSocket Proxy Fix

- `GatewayPlugin.createWebSocket()` now prefers `globalThis.WebSocket` before falling back to the Node `ws` package.
- Existing `webSocketFactory` override behavior is unchanged.

Why this matters:

- In modern Node runtimes, the built-in `WebSocket` can follow the runtime's env-proxy behavior.
- The `ws` package does not use `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` automatically.
- Carbon previously preferred `ws` on Node, which caused Discord gateway connections to ignore the proxy by default even when REST requests were proxy-aware.

This issue was causing problems in, for example, nemoclaw: https://github.com/NVIDIA/NemoClaw/issues/1738 where the proxy setting was not being respected by the websocket connection, so HTTP REST authentication works, but the websocket fails.

Added test:

- `packages/carbon/tests/plugins/gateway.test.ts`

## Minimal reproduction

This issue does not require NemoClaw or OpenShell specifically. A minimal reproduction is:

1. Run a Node environment where outbound network access must go through an HTTP proxy.
2. Set proxy environment variables such as:
   - `HTTPS_PROXY=http://proxy-host:3128`
   - `HTTP_PROXY=http://proxy-host:3128`
   - `ALL_PROXY=http://proxy-host:3128`
3. Use a WebSocket client path that relies on the `ws` package without explicitly passing an agent.
4. Connect to Discord's gateway:
   - `wss://gateway.discord.gg/?v=10&encoding=json`

Expected result:

- The connection should open and receive Discord's initial `op:10` Hello event.

Observed broken result before the fix:

- The connection bypasses the proxy.
- The client fails before READY, often with low-level network errors such as connect failures or DNS failures depending on the environment.

## Small reproduction script

Broken shape:

```js
import WebSocket from "ws";

const ws = new WebSocket("wss://gateway.discord.gg/?v=10&encoding=json");
ws.on("open", () => console.log("open"));
ws.on("message", (data) => console.log(data.toString()));
ws.on("error", (err) => console.error(err));
```

Working shape in proxy-only environments:

```js
const ws = new WebSocket("wss://gateway.discord.gg/?v=10&encoding=json");
ws.addEventListener("open", () => console.log("open"));
ws.addEventListener("message", (ev) => console.log(ev.data.toString()));
ws.addEventListener("error", (err) => console.error(err));
```

Or, if using `ws`, pass an explicit proxy agent.