### PR TITLE
feat: Redis forwarder plugin

### DIFF
--- a/.changeset/plain-berries-write.md
+++ b/.changeset/plain-berries-write.md
@@ -1,0 +1,9 @@
+---
+"@buape/carbon": minor
+---
+
+feat: add Redis Streams gateway forwarder/receiver plugins
+
+New `@buape/carbon/redis-gateway-forwarder` module with `RedisStreamGatewayForwarderPlugin` / `ShardedRedisStreamGatewayForwarderPlugin` (sender) and `RedisStreamGatewayReceiverPlugin` (receiver). This is an alternative to `GatewayForwarderPlugin`'s HTTP webhook for forwarding gateway events. Delivers via one Redis Stream per client.
+
+Delivery/registration errors are reported through `onDeliveryLatency`/`onDeliverError`/`onRegisterError`/`onBackpressure` callbacks (receiver) and the emitter`'s `"error"` event (sender).

--- a/.changeset/plain-berries-write.md
+++ b/.changeset/plain-berries-write.md
@@ -3,7 +3,3 @@
 ---
 
 feat: add Redis Streams gateway forwarder/receiver plugins
-
-New `@buape/carbon/redis-gateway-forwarder` module with `RedisStreamGatewayForwarderPlugin` / `ShardedRedisStreamGatewayForwarderPlugin` (sender) and `RedisStreamGatewayReceiverPlugin` (receiver). This is an alternative to `GatewayForwarderPlugin`'s HTTP webhook for forwarding gateway events. Delivers via one Redis Stream per client.
-
-Delivery/registration errors are reported through `onDeliveryLatency`/`onDeliverError`/`onRegisterError`/`onBackpressure` callbacks (receiver) and the emitter`'s `"error"` event (sender).

--- a/packages/carbon/package.json
+++ b/packages/carbon/package.json
@@ -30,6 +30,9 @@
 	"dependencies": {
 		"discord-api-types": "0.38.49"
 	},
+	"devDependencies": {
+		"ioredis": "^5.6.1"
+	},
 	"files": [
 		"dist",
 		"LICENSE"
@@ -37,7 +40,8 @@
 	"peerDependencies": {
 		"@discordjs/voice": "^0.19.2",
 		"@types/bun": ">=1.3.0",
-		"@types/node": ">=24.0.0"
+		"@types/node": ">=24.0.0",
+		"ioredis": "^5.6.1"
 	},
 	"peerDependenciesMeta": {
 		"@discordjs/voice": {
@@ -47,6 +51,9 @@
 			"optional": true
 		},
 		"@types/node": {
+			"optional": true
+		},
+		"ioredis": {
 			"optional": true
 		}
 	}

--- a/packages/carbon/src/plugins/redis-gateway-forwarder/RedisStreamGatewayForwarderPlugin.ts
+++ b/packages/carbon/src/plugins/redis-gateway-forwarder/RedisStreamGatewayForwarderPlugin.ts
@@ -1,15 +1,10 @@
 import type { Client } from "../../classes/Client.js"
+import type { RuntimeProfile } from "../../classes/RequestClient.js"
 import { createBoundedExecutor } from "../../internals/BoundedExecutor.js"
 import type { ListenerEventType } from "../../types/index.js"
 import { GatewayPlugin } from "../gateway/GatewayPlugin.js"
 import type { GatewayPayload, GatewayPluginOptions } from "../gateway/types.js"
-import {
-	deriveStreamKey,
-	type RedisStreamClient,
-	type VariadicRedisCommand
-} from "./types.js"
-
-type RuntimeProfile = "serverless" | "persistent"
+import type { RedisStreamClient } from "./types.js"
 
 export interface RedisStreamDeliveryOptions {
 	timeoutMs?: number
@@ -130,10 +125,14 @@ export class RedisStreamGatewayForwarderPlugin extends GatewayPlugin {
 			...defaults,
 			...options.delivery
 		}
-		assertPositiveInteger(
-			"delivery.maxInFlight",
-			this.deliveryPolicy.maxInFlight
-		)
+		if (
+			!Number.isInteger(this.deliveryPolicy.maxInFlight) ||
+			this.deliveryPolicy.maxInFlight < 1
+		) {
+			throw new Error(
+				"delivery.maxInFlight must be an integer greater than or equal to 1"
+			)
+		}
 		this.deliveryExecutor = createBoundedExecutor<DeliveryTask>({
 			concurrency: this.deliveryPolicy.maxInFlight,
 			run: async (task) => {
@@ -148,10 +147,7 @@ export class RedisStreamGatewayForwarderPlugin extends GatewayPlugin {
 	}
 
 	override async registerClient(client: Client): Promise<void> {
-		this.streamKey = deriveStreamKey(
-			client.clientId,
-			this.options.streamKeyPrefix
-		)
+		this.streamKey = `${this.options.streamKeyPrefix ?? "carbon:events"}:${client.clientId}`
 		return super.registerClient(client)
 	}
 
@@ -289,7 +285,9 @@ export class RedisStreamGatewayForwarderPlugin extends GatewayPlugin {
 			}
 
 			this.deliveryMetrics.retried += 1
-			await sleep(this.getRetryDelay(attempt))
+			await new Promise((resolve) => {
+				setTimeout(resolve, Math.max(0, this.getRetryDelay(attempt)))
+			})
 		}
 	}
 
@@ -309,9 +307,11 @@ export class RedisStreamGatewayForwarderPlugin extends GatewayPlugin {
 				]
 			: [this.streamKey, "*", ...task.fields]
 
-		const xadd = this.options.redis.xadd.bind(
-			this.options.redis
-		) as unknown as VariadicRedisCommand
+		const xadd = (
+			this.options.redis.xadd as unknown as (
+				...args: (string | number)[]
+			) => Promise<unknown>
+		).bind(this.options.redis)
 
 		let timeoutHandle: ReturnType<typeof setTimeout> | undefined
 		try {
@@ -354,12 +354,3 @@ export class RedisStreamGatewayForwarderPlugin extends GatewayPlugin {
 		this.failureReasons.set(reason, (this.failureReasons.get(reason) ?? 0) + 1)
 	}
 }
-
-function assertPositiveInteger(name: string, value: number) {
-	if (!Number.isInteger(value) || value < 1) {
-		throw new Error(`${name} must be an integer greater than or equal to 1`)
-	}
-}
-
-const sleep = (ms: number) =>
-	new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)))

--- a/packages/carbon/src/plugins/redis-gateway-forwarder/RedisStreamGatewayForwarderPlugin.ts
+++ b/packages/carbon/src/plugins/redis-gateway-forwarder/RedisStreamGatewayForwarderPlugin.ts
@@ -1,0 +1,365 @@
+import type { Client } from "../../classes/Client.js"
+import { createBoundedExecutor } from "../../internals/BoundedExecutor.js"
+import type { ListenerEventType } from "../../types/index.js"
+import { GatewayPlugin } from "../gateway/GatewayPlugin.js"
+import type { GatewayPayload, GatewayPluginOptions } from "../gateway/types.js"
+import {
+	deriveStreamKey,
+	type RedisStreamClient,
+	type VariadicRedisCommand
+} from "./types.js"
+
+type RuntimeProfile = "serverless" | "persistent"
+
+export interface RedisStreamDeliveryOptions {
+	timeoutMs?: number
+	maxRetries?: number
+	baseBackoffMs?: number
+	maxBackoffMs?: number
+	jitterRatio?: number
+	maxInFlight?: number
+	maxQueueSize?: number
+}
+
+export interface RedisStreamGatewayForwarderPluginOptions
+	extends GatewayPluginOptions {
+	/**
+	 * The ioredis client (or cluster client) to publish gateway events to.
+	 * This connection is owned and managed by the caller.
+	 */
+	redis: RedisStreamClient
+	/**
+	 * Prefix used to derive the per-client stream key (`<prefix>:<clientId>`).
+	 *
+	 * @default "carbon:events"
+	 */
+	streamKeyPrefix?: string
+	/**
+	 * Approximate maximum stream length (`XADD ... MAXLEN ~ N`), used to bound
+	 * unbounded stream growth. Set to `undefined` to disable trimming.
+	 *
+	 * @default 100_000
+	 */
+	maxStreamLength?: number
+	/**
+	 * Runtime profile that controls delivery defaults.
+	 *
+	 * @default "serverless"
+	 */
+	runtimeProfile?: RuntimeProfile
+	/**
+	 * Delivery policy for forwarded events.
+	 */
+	delivery?: RedisStreamDeliveryOptions
+}
+
+type DeliveryTask = {
+	eventType: string
+	fields: string[]
+	attempt: number
+	enqueuedAt: number
+}
+
+const deliveryDefaults = {
+	serverless: {
+		timeoutMs: 2500,
+		maxRetries: 2,
+		baseBackoffMs: 150,
+		maxBackoffMs: 1800,
+		jitterRatio: 0.2,
+		maxInFlight: 8,
+		maxQueueSize: 2000
+	},
+	persistent: {
+		timeoutMs: 6000,
+		maxRetries: 3,
+		baseBackoffMs: 250,
+		maxBackoffMs: 4000,
+		jitterRatio: 0.2,
+		maxInFlight: 16,
+		maxQueueSize: 8000
+	}
+} satisfies Record<RuntimeProfile, Required<RedisStreamDeliveryOptions>>
+
+/**
+ * Forwards gateway events to a Redis Stream (one stream per client) instead of
+ * a signed HTTP webhook. Intended for trusted, internal delivery between a
+ * gateway-connected forwarder process and a processor that consumes the
+ * stream with `RedisStreamGatewayReceiverPlugin`.
+ *
+ * Delivery and message-parsing failures are reported through the inherited
+ * `emitter`'s `"error"` event (the same channel `GatewayPlugin` already uses
+ * for websocket-level errors), not by throwing. Both failure paths happen
+ * inside a websocket message handler and a background bounded-executor retry
+ * loop — neither is awaited by anything, so a thrown error there would only
+ * become an unhandled promise rejection instead of reaching a caller.
+ * Subscribe with `plugin.emitter.on("error", (error) => ...)`, exactly how
+ * `ForwarderRuntime.attachForwarderErrorHandler` already does for the base
+ * gateway connection.
+ */
+export class RedisStreamGatewayForwarderPlugin extends GatewayPlugin {
+	override readonly id = "redis-gateway-forwarder" as "gateway"
+
+	readonly options: RedisStreamGatewayForwarderPluginOptions
+	private streamKey?: string
+	private guildAvailabilityCache: Map<string, boolean> = new Map()
+	private deliveryPolicy: Required<RedisStreamDeliveryOptions>
+	private deliveryExecutor: ReturnType<
+		typeof createBoundedExecutor<DeliveryTask>
+	>
+	private deliveryMetrics = {
+		accepted: 0,
+		sent: 0,
+		retried: 0,
+		failed: 0,
+		dropped: 0,
+		timeouts: 0,
+		lastFailureReason: null as string | null,
+		lastFailureEventType: null as string | null,
+		lastFailureAt: 0,
+		lastSuccessAt: 0,
+		oldestQueuedAgeMs: 0
+	}
+	private failureReasons = new Map<string, number>()
+
+	constructor(options: RedisStreamGatewayForwarderPluginOptions) {
+		super(options)
+		const profile = options.runtimeProfile ?? "serverless"
+		const defaults = deliveryDefaults[profile]
+		this.deliveryPolicy = {
+			...defaults,
+			...options.delivery
+		}
+		assertPositiveInteger(
+			"delivery.maxInFlight",
+			this.deliveryPolicy.maxInFlight
+		)
+		this.deliveryExecutor = createBoundedExecutor<DeliveryTask>({
+			concurrency: this.deliveryPolicy.maxInFlight,
+			run: async (task) => {
+				await this.deliver(task)
+			},
+			getQueuedAt: (task) => task.enqueuedAt
+		})
+		this.options = {
+			maxStreamLength: 100_000,
+			...options
+		}
+	}
+
+	override async registerClient(client: Client): Promise<void> {
+		this.streamKey = deriveStreamKey(
+			client.clientId,
+			this.options.streamKeyPrefix
+		)
+		return super.registerClient(client)
+	}
+
+	protected override setupWebSocket(): void {
+		super.setupWebSocket()
+
+		if (!this.ws) return
+
+		this.onSocketEvent(this.ws, "message", async (incoming) => {
+			try {
+				const payloadText = this.getMessageText(incoming)
+				if (!payloadText) {
+					return
+				}
+				const payload = JSON.parse(payloadText) as GatewayPayload
+
+				if (payload.t && payload.d) {
+					const gatewayType = payload.t as ListenerEventType
+					let forwardedType = gatewayType
+
+					if (gatewayType === "READY") {
+						const readyData = payload.d as {
+							guilds?: Array<{ id: string }>
+						}
+						this.guildAvailabilityCache.clear()
+						readyData.guilds?.forEach((guild) => {
+							this.guildAvailabilityCache.set(guild.id, false)
+						})
+					}
+
+					if (gatewayType === "GUILD_CREATE") {
+						const guildCreateData = payload.d as { id: string }
+						const cachedAvailability = this.guildAvailabilityCache.get(
+							guildCreateData.id
+						)
+						if (cachedAvailability === false) {
+							forwardedType = "GUILD_AVAILABLE"
+						}
+						this.guildAvailabilityCache.set(guildCreateData.id, true)
+					}
+
+					if (gatewayType === "GUILD_DELETE") {
+						const guildDeleteData = payload.d as {
+							id: string
+							unavailable?: boolean
+						}
+						if (guildDeleteData.unavailable) {
+							forwardedType = "GUILD_UNAVAILABLE"
+							this.guildAvailabilityCache.set(guildDeleteData.id, false)
+						} else {
+							this.guildAvailabilityCache.delete(guildDeleteData.id)
+						}
+					}
+
+					if (
+						this.options.eventFilter &&
+						!this.options.eventFilter(forwardedType)
+					) {
+						return
+					}
+
+					this.enqueueDelivery({
+						eventType: forwardedType,
+						fields: [
+							"type",
+							forwardedType,
+							"data",
+							JSON.stringify(payload.d),
+							"ts",
+							String(Date.now())
+						],
+						attempt: 0,
+						enqueuedAt: Date.now()
+					})
+				}
+			} catch (error) {
+				this.emitter.emit(
+					"error",
+					error instanceof Error
+						? error
+						: new Error(`Error forwarding gateway event to Redis: ${error}`)
+				)
+			}
+		})
+	}
+
+	getDeliveryMetrics() {
+		this.deliveryMetrics.oldestQueuedAgeMs =
+			this.deliveryExecutor.getOldestQueuedAgeMs()
+		return {
+			...this.deliveryMetrics,
+			queueDepth: this.deliveryExecutor.getQueueDepth(),
+			inFlight: this.deliveryExecutor.getInFlight(),
+			policy: this.deliveryPolicy,
+			failureReasons: Object.fromEntries(this.failureReasons)
+		}
+	}
+
+	private enqueueDelivery(task: DeliveryTask) {
+		if (
+			this.deliveryExecutor.getQueueDepth() >= this.deliveryPolicy.maxQueueSize
+		) {
+			this.deliveryMetrics.dropped += 1
+			this.trackFailure("queue_full", task.eventType)
+			return
+		}
+		this.deliveryMetrics.accepted += 1
+		this.deliveryExecutor.schedule(task)
+	}
+
+	private async deliver(task: DeliveryTask) {
+		for (
+			let attempt = task.attempt;
+			attempt <= this.deliveryPolicy.maxRetries;
+			attempt += 1
+		) {
+			const response = await this.sendWithTimeout(task)
+			if (response.ok) {
+				this.deliveryMetrics.sent += 1
+				this.deliveryMetrics.lastSuccessAt = Date.now()
+				return
+			}
+
+			const finalAttempt = attempt >= this.deliveryPolicy.maxRetries
+			if (finalAttempt) {
+				this.deliveryMetrics.failed += 1
+				this.trackFailure(response.reason, task.eventType)
+				this.emitter.emit(
+					"error",
+					new Error(
+						`redis-gateway-forwarder delivery failed for event ${task.eventType} after ${attempt + 1}/${this.deliveryPolicy.maxRetries + 1} attempt(s): ${response.reason}`
+					)
+				)
+				return
+			}
+
+			this.deliveryMetrics.retried += 1
+			await sleep(this.getRetryDelay(attempt))
+		}
+	}
+
+	private async sendWithTimeout(task: DeliveryTask) {
+		if (!this.streamKey) {
+			return { ok: false, reason: "no_stream_key" } as const
+		}
+
+		const args: (string | number)[] = this.options.maxStreamLength
+			? [
+					this.streamKey,
+					"MAXLEN",
+					"~",
+					this.options.maxStreamLength,
+					"*",
+					...task.fields
+				]
+			: [this.streamKey, "*", ...task.fields]
+
+		const xadd = this.options.redis.xadd.bind(
+			this.options.redis
+		) as unknown as VariadicRedisCommand
+
+		let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+		try {
+			const result = await Promise.race([
+				xadd(...args),
+				new Promise<never>((_, reject) => {
+					timeoutHandle = setTimeout(() => {
+						this.deliveryMetrics.timeouts += 1
+						reject(new Error("redis-gateway-forwarder timeout"))
+					}, this.deliveryPolicy.timeoutMs)
+				})
+			])
+			if (result === null || result === undefined) {
+				return { ok: false, reason: "xadd_null" } as const
+			}
+			return { ok: true, reason: "ok" } as const
+		} catch (error) {
+			return {
+				ok: false,
+				reason:
+					error instanceof Error ? `redis:${error.message}` : "redis:unknown"
+			} as const
+		} finally {
+			if (timeoutHandle) clearTimeout(timeoutHandle)
+		}
+	}
+
+	private getRetryDelay(attempt: number) {
+		const base = this.deliveryPolicy.baseBackoffMs * 2 ** attempt
+		const bounded = Math.min(base, this.deliveryPolicy.maxBackoffMs)
+		const jitter = this.deliveryPolicy.jitterRatio
+		const factor = 1 - jitter + Math.random() * jitter * 2
+		return Math.max(0, Math.floor(bounded * factor))
+	}
+
+	private trackFailure(reason: string, eventType: string) {
+		this.deliveryMetrics.lastFailureReason = reason
+		this.deliveryMetrics.lastFailureEventType = eventType
+		this.deliveryMetrics.lastFailureAt = Date.now()
+		this.failureReasons.set(reason, (this.failureReasons.get(reason) ?? 0) + 1)
+	}
+}
+
+function assertPositiveInteger(name: string, value: number) {
+	if (!Number.isInteger(value) || value < 1) {
+		throw new Error(`${name} must be an integer greater than or equal to 1`)
+	}
+}
+
+const sleep = (ms: number) =>
+	new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)))

--- a/packages/carbon/src/plugins/redis-gateway-forwarder/RedisStreamGatewayReceiverPlugin.ts
+++ b/packages/carbon/src/plugins/redis-gateway-forwarder/RedisStreamGatewayReceiverPlugin.ts
@@ -1,17 +1,7 @@
 import { Plugin } from "../../abstracts/Plugin.js"
 import type { Client } from "../../classes/Client.js"
 import type { ListenerEventType } from "../../types/index.js"
-import {
-	deriveStreamKey,
-	parseStreamEntryFields,
-	type RedisStreamClient,
-	type VariadicRedisCommand
-} from "./types.js"
-
-type RawStreamEntry = [id: string, fields: string[] | null]
-type RawStreamReadResult =
-	| [streamKey: string, entries: RawStreamEntry[]][]
-	| null
+import type { RedisStreamClient } from "./types.js"
 
 export interface RedisStreamGatewayReceiverPluginOptions {
 	/** Non-blocking connection used for XGROUP/XACK/XAUTOCLAIM admin commands. */
@@ -91,11 +81,6 @@ export interface RedisStreamGatewayReceiverPluginOptions {
 	) => void
 }
 
-interface WatchedStream {
-	client: Client
-	streamKey: string
-}
-
 // Only used when there is nothing to wait on yet (no client has registered a
 // stream at all) — there's no backoff timer or blocking read to compute a
 // precise wake time from, so this is a genuine, if rare, poll.
@@ -104,9 +89,6 @@ const minBackoffWaitMs = 25
 const baseBackoffMs = 200
 const maxBackoffMs = 10_000
 const autoclaimMaxPages = 10
-
-const sleep = (ms: number) =>
-	new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)))
 
 /**
  * Receives gateway events from Redis Streams (one stream per client),
@@ -150,7 +132,10 @@ export class RedisStreamGatewayReceiverPlugin extends Plugin {
 			| "onDeliveryLatency"
 		>
 
-	private watchedStreams = new Map<string, WatchedStream>()
+	private watchedStreams = new Map<
+		string,
+		{ client: Client; streamKey: string }
+	>()
 	private backoffUntil = new Map<string, number>()
 	private backoffAttempt = new Map<string, number>()
 	private loopRunning = false
@@ -177,10 +162,7 @@ export class RedisStreamGatewayReceiverPlugin extends Plugin {
 	}
 
 	async registerClient(client: Client): Promise<void> {
-		const streamKey = deriveStreamKey(
-			client.clientId,
-			this.options.streamKeyPrefix
-		)
+		const streamKey = `${this.options.streamKeyPrefix}:${client.clientId}`
 		this.watchedStreams.set(client.clientId, { client, streamKey })
 
 		const xgroup = this.bindCommand(this.options.redis, "xgroup")
@@ -193,7 +175,7 @@ export class RedisStreamGatewayReceiverPlugin extends Plugin {
 				"MKSTREAM"
 			)
 		} catch (error) {
-			if (!this.isBusyGroupError(error)) {
+			if (!(error instanceof Error && error.message.includes("BUSYGROUP"))) {
 				this.options.onRegisterError?.(client.clientId, error)
 			}
 		}
@@ -234,14 +216,12 @@ export class RedisStreamGatewayReceiverPlugin extends Plugin {
 	private bindCommand(
 		client: RedisStreamClient,
 		name: "xgroup" | "xack" | "xautoclaim" | "xreadgroup"
-	): VariadicRedisCommand {
+	): (...args: (string | number)[]) => Promise<unknown> {
 		return (
-			client[name] as unknown as (...args: unknown[]) => Promise<unknown>
-		).bind(client) as VariadicRedisCommand
-	}
-
-	private isBusyGroupError(error: unknown): boolean {
-		return error instanceof Error && error.message.includes("BUSYGROUP")
+			client[name] as unknown as (
+				...args: (string | number)[]
+			) => Promise<unknown>
+		).bind(client)
 	}
 
 	private isBackedOff(streamKey: string): boolean {
@@ -266,7 +246,7 @@ export class RedisStreamGatewayReceiverPlugin extends Plugin {
 	 * fully-backed-off loop iteration can sleep exactly that long instead of
 	 * polling on a fixed interval.
 	 */
-	private getBackoffWaitMs(streams: WatchedStream[]): number {
+	private getBackoffWaitMs(streams: Array<{ streamKey: string }>): number {
 		const now = Date.now()
 		let soonest = Number.POSITIVE_INFINITY
 		for (const { streamKey } of streams) {
@@ -284,7 +264,9 @@ export class RedisStreamGatewayReceiverPlugin extends Plugin {
 			while (!this.stopRequested) {
 				const watched = [...this.watchedStreams.values()]
 				if (watched.length === 0) {
-					await sleep(idlePollMs)
+					await new Promise((resolve) => {
+						setTimeout(resolve, idlePollMs)
+					})
 					continue
 				}
 
@@ -300,7 +282,9 @@ export class RedisStreamGatewayReceiverPlugin extends Plugin {
 					(entry) => !this.isBackedOff(entry.streamKey)
 				)
 				if (activeStreams.length === 0) {
-					await sleep(this.getBackoffWaitMs(watched))
+					await new Promise((resolve) => {
+						setTimeout(resolve, this.getBackoffWaitMs(watched))
+					})
 					continue
 				}
 
@@ -315,7 +299,9 @@ export class RedisStreamGatewayReceiverPlugin extends Plugin {
 					(entry) => !this.isBackedOff(entry.streamKey)
 				)
 				if (stillActive.length === 0) {
-					await sleep(this.getBackoffWaitMs(activeStreams))
+					await new Promise((resolve) => {
+						setTimeout(resolve, this.getBackoffWaitMs(activeStreams))
+					})
 					continue
 				}
 
@@ -326,7 +312,9 @@ export class RedisStreamGatewayReceiverPlugin extends Plugin {
 		}
 	}
 
-	private async drainPending(watched: WatchedStream[]): Promise<void> {
+	private async drainPending(
+		watched: Array<{ streamKey: string }>
+	): Promise<void> {
 		const xreadgroup = this.bindCommand(
 			this.options.blockingRedis,
 			"xreadgroup"
@@ -341,12 +329,16 @@ export class RedisStreamGatewayReceiverPlugin extends Plugin {
 			"STREAMS",
 			...streamKeys,
 			...streamKeys.map(() => "0")
-		)) as RawStreamReadResult
+		)) as
+			| [streamKey: string, entries: [id: string, fields: string[] | null][]][]
+			| null
 		if (!result) return
 		await this.processResult(result, { isReplay: true })
 	}
 
-	private async readNewEntries(watched: WatchedStream[]): Promise<void> {
+	private async readNewEntries(
+		watched: Array<{ streamKey: string }>
+	): Promise<void> {
 		const xreadgroup = this.bindCommand(
 			this.options.blockingRedis,
 			"xreadgroup"
@@ -363,13 +355,18 @@ export class RedisStreamGatewayReceiverPlugin extends Plugin {
 			"STREAMS",
 			...streamKeys,
 			...streamKeys.map(() => ">")
-		)) as RawStreamReadResult
+		)) as
+			| [streamKey: string, entries: [id: string, fields: string[] | null][]][]
+			| null
 		if (!result) return
 		await this.processResult(result, { isReplay: false })
 	}
 
 	private async processResult(
-		result: NonNullable<RawStreamReadResult>,
+		result: [
+			streamKey: string,
+			entries: [id: string, fields: string[] | null][]
+		][],
 		{ isReplay }: { isReplay: boolean }
 	): Promise<void> {
 		for (const [streamKey, entries] of result) {
@@ -386,7 +383,27 @@ export class RedisStreamGatewayReceiverPlugin extends Plugin {
 					continue
 				}
 
-				const { type, data, enqueuedAt } = parseStreamEntryFields(fields)
+				let type = "unknown"
+				let data: unknown = null
+				let enqueuedAt: number | undefined
+				for (let i = 0; i < fields.length; i += 2) {
+					const field = fields[i]
+					const value = fields[i + 1]
+					if (field === "type" && typeof value === "string") {
+						type = value
+					}
+					if (field === "data" && typeof value === "string") {
+						try {
+							data = JSON.parse(value)
+						} catch {
+							data = null
+						}
+					}
+					if (field === "ts" && typeof value === "string") {
+						const parsed = Number(value)
+						if (Number.isFinite(parsed)) enqueuedAt = parsed
+					}
+				}
 				let enqueued: boolean
 				try {
 					enqueued = watched.client.eventHandler.handleEvent(
@@ -422,7 +439,9 @@ export class RedisStreamGatewayReceiverPlugin extends Plugin {
 		}
 	}
 
-	private async runAutoclaimSweep(watched: WatchedStream[]): Promise<void> {
+	private async runAutoclaimSweep(
+		watched: Array<{ streamKey: string }>
+	): Promise<void> {
 		const xautoclaim = this.bindCommand(this.options.redis, "xautoclaim")
 		for (const { streamKey } of watched) {
 			let cursor = "0-0"
@@ -435,7 +454,9 @@ export class RedisStreamGatewayReceiverPlugin extends Plugin {
 					cursor,
 					"COUNT",
 					this.options.batchCount
-				).catch(() => null)) as [string, RawStreamEntry[], string[]?] | null
+				).catch(() => null)) as
+					| [string, [id: string, fields: string[] | null][], string[]?]
+					| null
 				if (!result) break
 
 				const [nextCursor, claimed] = result

--- a/packages/carbon/src/plugins/redis-gateway-forwarder/RedisStreamGatewayReceiverPlugin.ts
+++ b/packages/carbon/src/plugins/redis-gateway-forwarder/RedisStreamGatewayReceiverPlugin.ts
@@ -1,0 +1,457 @@
+import { Plugin } from "../../abstracts/Plugin.js"
+import type { Client } from "../../classes/Client.js"
+import type { ListenerEventType } from "../../types/index.js"
+import {
+	deriveStreamKey,
+	parseStreamEntryFields,
+	type RedisStreamClient,
+	type VariadicRedisCommand
+} from "./types.js"
+
+type RawStreamEntry = [id: string, fields: string[] | null]
+type RawStreamReadResult =
+	| [streamKey: string, entries: RawStreamEntry[]][]
+	| null
+
+export interface RedisStreamGatewayReceiverPluginOptions {
+	/** Non-blocking connection used for XGROUP/XACK/XAUTOCLAIM admin commands. */
+	redis: RedisStreamClient
+	/**
+	 * A dedicated connection (e.g. `redis.duplicate()`) used exclusively for the
+	 * blocking XREADGROUP read loop. Must not be shared with `redis` or any
+	 * other blocking/subscribe usage — a connection blocked in XREADGROUP can't
+	 * service other commands until the block returns.
+	 */
+	blockingRedis: RedisStreamClient
+	/** Redis consumer group name shared by every processor replica. */
+	consumerGroup: string
+	/** Unique consumer name for this process/replica, e.g. `${hostname}:${pid}`. */
+	consumerName: string
+	/**
+	 * Prefix used to derive the per-client stream key (`<prefix>:<clientId>`).
+	 * Must match the sender's `streamKeyPrefix`.
+	 *
+	 * @default "carbon:events"
+	 */
+	streamKeyPrefix?: string
+	/**
+	 * How long each `XREADGROUP` blocks waiting for new entries, in ms. This
+	 * is a real blocking wait, not a poll — Redis holds the connection open
+	 * and replies the instant an entry lands on any watched stream (or when
+	 * `blockMs` elapses with nothing new), so there's no busy looping while
+	 * traffic is flowing. The bound only matters for two edge cases: noticing
+	 * a stream `registerClient`'d during a total lull with zero events across
+	 * every other watched stream, and pacing the periodic `XAUTOCLAIM` sweep
+	 * (see `autoclaimIntervalMs`) — both of which are naturally rare since a
+	 * live gateway connection is rarely fully silent.
+	 *
+	 * @default 5000
+	 */
+	blockMs?: number
+	/** Max entries read per stream per XREADGROUP call.
+	 *
+	 * @default 50
+	 */
+	batchCount?: number
+	/** How often to sweep for stale pending entries from dead consumers, in ms.
+	 *
+	 * @default 30_000
+	 */
+	autoclaimIntervalMs?: number
+	/** Minimum idle time before a pending entry is considered stale/claimable.
+	 *
+	 * @default 30_000
+	 */
+	autoclaimMinIdleMs?: number
+	/** Called when a client's event queue is full and an entry is left unacked. */
+	onBackpressure?: (clientId: string) => void
+	/** Called when dispatching an entry to a client's listeners throws. */
+	onDeliverError?: (clientId: string, error: unknown) => void
+	/**
+	 * Called when creating a client's consumer group fails for a reason other
+	 * than the group already existing (e.g. the stream's Redis is briefly
+	 * unreachable). The client is still watched — its stream just won't be
+	 * read from a Redis-level consumer group until this succeeds, so a later
+	 * `registerClient` call (or Carbon's own client-recreate path) can recover.
+	 */
+	onRegisterError?: (clientId: string, error: unknown) => void
+	/**
+	 * Called for every entry successfully delivered to a client's listeners,
+	 * with the end-to-end latency (ms) from when the forwarder first received
+	 * the gateway event (the entry's `ts` field) to right now. `isReplay` is
+	 * true for entries delivered via the own-pending drain or an `XAUTOCLAIM`
+	 * sweep rather than a fresh `>` read — a high replay latency reflects
+	 * recovery time (a stalled consumer, a processor restart), not steady-state
+	 * pipeline latency, so callers should usually track these separately.
+	 */
+	onDeliveryLatency?: (
+		clientId: string,
+		latencyMs: number,
+		context: { isReplay: boolean }
+	) => void
+}
+
+interface WatchedStream {
+	client: Client
+	streamKey: string
+}
+
+// Only used when there is nothing to wait on yet (no client has registered a
+// stream at all) — there's no backoff timer or blocking read to compute a
+// precise wake time from, so this is a genuine, if rare, poll.
+const idlePollMs = 1000
+const minBackoffWaitMs = 25
+const baseBackoffMs = 200
+const maxBackoffMs = 10_000
+const autoclaimMaxPages = 10
+
+const sleep = (ms: number) =>
+	new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)))
+
+/**
+ * Receives gateway events from Redis Streams (one stream per client),
+ * multiplexed through a single blocking XREADGROUP loop shared across every
+ * client `registerClient`s this plugin instance with. Meant to be
+ * instantiated once and passed to a `ClientManager`'s shared `initialPlugins`
+ * (the same pattern `SayPlugin`/`CommandDataPlugin` already rely on), so
+ * `registerClient` is called once per tenant `Client`.
+ *
+ * Errors are reported through the `onRegisterError`/`onDeliverError`/
+ * `onBackpressure` callbacks, never by throwing. `registerClient` is called
+ * by Carbon's `Client` constructor without being awaited (constructors can't
+ * be async), and the read loop is a detached background task with no caller
+ * either — a thrown error in either place would only surface as an unhandled
+ * promise rejection (which can crash the process) rather than reach anything
+ * that could catch it. The callbacks give the host application an explicit,
+ * safe place to observe and log these failures instead.
+ */
+export class RedisStreamGatewayReceiverPlugin extends Plugin {
+	readonly id = "redis-gateway-receiver"
+
+	private readonly options: Required<
+		Pick<
+			RedisStreamGatewayReceiverPluginOptions,
+			| "redis"
+			| "blockingRedis"
+			| "consumerGroup"
+			| "consumerName"
+			| "streamKeyPrefix"
+			| "blockMs"
+			| "batchCount"
+			| "autoclaimIntervalMs"
+			| "autoclaimMinIdleMs"
+		>
+	> &
+		Pick<
+			RedisStreamGatewayReceiverPluginOptions,
+			| "onBackpressure"
+			| "onDeliverError"
+			| "onRegisterError"
+			| "onDeliveryLatency"
+		>
+
+	private watchedStreams = new Map<string, WatchedStream>()
+	private backoffUntil = new Map<string, number>()
+	private backoffAttempt = new Map<string, number>()
+	private loopRunning = false
+	private stopRequested = false
+	private lastAutoclaimAt = 0
+	private metrics = {
+		backpressureSkips: 0,
+		autoclaimReclaimed: 0,
+		pendingDrainReplayed: 0,
+		processed: 0,
+		failed: 0
+	}
+
+	constructor(options: RedisStreamGatewayReceiverPluginOptions) {
+		super()
+		this.options = {
+			streamKeyPrefix: "carbon:events",
+			blockMs: 5000,
+			batchCount: 50,
+			autoclaimIntervalMs: 30_000,
+			autoclaimMinIdleMs: 30_000,
+			...options
+		}
+	}
+
+	async registerClient(client: Client): Promise<void> {
+		const streamKey = deriveStreamKey(
+			client.clientId,
+			this.options.streamKeyPrefix
+		)
+		this.watchedStreams.set(client.clientId, { client, streamKey })
+
+		const xgroup = this.bindCommand(this.options.redis, "xgroup")
+		try {
+			await xgroup(
+				"CREATE",
+				streamKey,
+				this.options.consumerGroup,
+				"$",
+				"MKSTREAM"
+			)
+		} catch (error) {
+			if (!this.isBusyGroupError(error)) {
+				this.options.onRegisterError?.(client.clientId, error)
+			}
+		}
+
+		if (!this.loopRunning) {
+			this.loopRunning = true
+			this.stopRequested = false
+			void this.runLoop()
+		}
+	}
+
+	/**
+	 * Stops watching a client's stream. Deliberately does not destroy the
+	 * consumer group or delete the stream — a disabled-then-re-enabled client
+	 * should resume from anything still pending, not lose it.
+	 */
+	detach(clientId: string): void {
+		this.watchedStreams.delete(clientId)
+	}
+
+	/**
+	 * Signals the read loop to stop after its current blocking call returns
+	 * (up to `blockMs`). Does not touch the injected connections — the caller
+	 * owns their lifecycle and can disconnect `blockingRedis` itself right
+	 * after calling `stop()` for a faster shutdown.
+	 */
+	stop(): void {
+		this.stopRequested = true
+	}
+
+	getMetrics() {
+		return {
+			watchedStreamCount: this.watchedStreams.size,
+			...this.metrics
+		}
+	}
+
+	private bindCommand(
+		client: RedisStreamClient,
+		name: "xgroup" | "xack" | "xautoclaim" | "xreadgroup"
+	): VariadicRedisCommand {
+		return (
+			client[name] as unknown as (...args: unknown[]) => Promise<unknown>
+		).bind(client) as VariadicRedisCommand
+	}
+
+	private isBusyGroupError(error: unknown): boolean {
+		return error instanceof Error && error.message.includes("BUSYGROUP")
+	}
+
+	private isBackedOff(streamKey: string): boolean {
+		const until = this.backoffUntil.get(streamKey)
+		return typeof until === "number" && until > Date.now()
+	}
+
+	private setBackoff(streamKey: string): void {
+		const attempt = (this.backoffAttempt.get(streamKey) ?? 0) + 1
+		this.backoffAttempt.set(streamKey, attempt)
+		const delay = Math.min(baseBackoffMs * 2 ** (attempt - 1), maxBackoffMs)
+		this.backoffUntil.set(streamKey, Date.now() + delay)
+	}
+
+	private clearBackoff(streamKey: string): void {
+		this.backoffAttempt.delete(streamKey)
+		this.backoffUntil.delete(streamKey)
+	}
+
+	/**
+	 * Milliseconds until the soonest backoff among `streams` clears, so a
+	 * fully-backed-off loop iteration can sleep exactly that long instead of
+	 * polling on a fixed interval.
+	 */
+	private getBackoffWaitMs(streams: WatchedStream[]): number {
+		const now = Date.now()
+		let soonest = Number.POSITIVE_INFINITY
+		for (const { streamKey } of streams) {
+			const until = this.backoffUntil.get(streamKey)
+			if (typeof until === "number") {
+				soonest = Math.min(soonest, until - now)
+			}
+		}
+		if (!Number.isFinite(soonest)) return minBackoffWaitMs
+		return Math.max(minBackoffWaitMs, soonest)
+	}
+
+	private async runLoop(): Promise<void> {
+		try {
+			while (!this.stopRequested) {
+				const watched = [...this.watchedStreams.values()]
+				if (watched.length === 0) {
+					await sleep(idlePollMs)
+					continue
+				}
+
+				if (
+					Date.now() - this.lastAutoclaimAt >
+					this.options.autoclaimIntervalMs
+				) {
+					await this.runAutoclaimSweep(watched)
+					this.lastAutoclaimAt = Date.now()
+				}
+
+				const activeStreams = watched.filter(
+					(entry) => !this.isBackedOff(entry.streamKey)
+				)
+				if (activeStreams.length === 0) {
+					await sleep(this.getBackoffWaitMs(watched))
+					continue
+				}
+
+				// Always drain each active stream's own previously-delivered-but-
+				// unacked entries before reading new ones. This covers both an
+				// unclean restart reusing this consumer name, and a stream
+				// recovering from a backpressure backoff (`>` only ever returns
+				// entries this consumer hasn't already been handed, so a skipped
+				// entry can only be retried through an explicit "0" read).
+				await this.drainPending(activeStreams)
+				const stillActive = activeStreams.filter(
+					(entry) => !this.isBackedOff(entry.streamKey)
+				)
+				if (stillActive.length === 0) {
+					await sleep(this.getBackoffWaitMs(activeStreams))
+					continue
+				}
+
+				await this.readNewEntries(stillActive)
+			}
+		} finally {
+			this.loopRunning = false
+		}
+	}
+
+	private async drainPending(watched: WatchedStream[]): Promise<void> {
+		const xreadgroup = this.bindCommand(
+			this.options.blockingRedis,
+			"xreadgroup"
+		)
+		const streamKeys = watched.map((entry) => entry.streamKey)
+		const result = (await xreadgroup(
+			"GROUP",
+			this.options.consumerGroup,
+			this.options.consumerName,
+			"COUNT",
+			this.options.batchCount,
+			"STREAMS",
+			...streamKeys,
+			...streamKeys.map(() => "0")
+		)) as RawStreamReadResult
+		if (!result) return
+		await this.processResult(result, { isReplay: true })
+	}
+
+	private async readNewEntries(watched: WatchedStream[]): Promise<void> {
+		const xreadgroup = this.bindCommand(
+			this.options.blockingRedis,
+			"xreadgroup"
+		)
+		const streamKeys = watched.map((entry) => entry.streamKey)
+		const result = (await xreadgroup(
+			"GROUP",
+			this.options.consumerGroup,
+			this.options.consumerName,
+			"BLOCK",
+			this.options.blockMs,
+			"COUNT",
+			this.options.batchCount,
+			"STREAMS",
+			...streamKeys,
+			...streamKeys.map(() => ">")
+		)) as RawStreamReadResult
+		if (!result) return
+		await this.processResult(result, { isReplay: false })
+	}
+
+	private async processResult(
+		result: NonNullable<RawStreamReadResult>,
+		{ isReplay }: { isReplay: boolean }
+	): Promise<void> {
+		for (const [streamKey, entries] of result) {
+			const watched = [...this.watchedStreams.values()].find(
+				(entry) => entry.streamKey === streamKey
+			)
+			if (!watched) continue
+
+			for (const [id, fields] of entries) {
+				if (!fields || fields.length === 0) {
+					// Entry data is gone (e.g. trimmed by MAXLEN) but still pending;
+					// nothing left to deliver, so just clear it from the PEL.
+					await this.ack(streamKey, id)
+					continue
+				}
+
+				const { type, data, enqueuedAt } = parseStreamEntryFields(fields)
+				let enqueued: boolean
+				try {
+					enqueued = watched.client.eventHandler.handleEvent(
+						{ ...(data as object), clientId: watched.client.clientId },
+						type as ListenerEventType
+					)
+				} catch (error) {
+					this.metrics.failed += 1
+					this.options.onDeliverError?.(watched.client.clientId, error)
+					this.setBackoff(streamKey)
+					break
+				}
+
+				if (!enqueued) {
+					this.metrics.backpressureSkips += 1
+					this.options.onBackpressure?.(watched.client.clientId)
+					this.setBackoff(streamKey)
+					break
+				}
+
+				this.clearBackoff(streamKey)
+				this.metrics.processed += 1
+				if (isReplay) this.metrics.pendingDrainReplayed += 1
+				if (enqueuedAt !== undefined) {
+					this.options.onDeliveryLatency?.(
+						watched.client.clientId,
+						Math.max(0, Date.now() - enqueuedAt),
+						{ isReplay }
+					)
+				}
+				await this.ack(streamKey, id)
+			}
+		}
+	}
+
+	private async runAutoclaimSweep(watched: WatchedStream[]): Promise<void> {
+		const xautoclaim = this.bindCommand(this.options.redis, "xautoclaim")
+		for (const { streamKey } of watched) {
+			let cursor = "0-0"
+			for (let page = 0; page < autoclaimMaxPages; page += 1) {
+				const result = (await xautoclaim(
+					streamKey,
+					this.options.consumerGroup,
+					this.options.consumerName,
+					this.options.autoclaimMinIdleMs,
+					cursor,
+					"COUNT",
+					this.options.batchCount
+				).catch(() => null)) as [string, RawStreamEntry[], string[]?] | null
+				if (!result) break
+
+				const [nextCursor, claimed] = result
+				if (claimed.length > 0) {
+					this.metrics.autoclaimReclaimed += claimed.length
+					await this.processResult([[streamKey, claimed]], { isReplay: true })
+				}
+
+				cursor = nextCursor
+				if (cursor === "0-0" || claimed.length === 0) break
+			}
+		}
+	}
+
+	private async ack(streamKey: string, id: string): Promise<void> {
+		const xack = this.bindCommand(this.options.redis, "xack")
+		await xack(streamKey, this.options.consumerGroup, id).catch(() => {})
+	}
+}

--- a/packages/carbon/src/plugins/redis-gateway-forwarder/ShardedRedisStreamGatewayForwarderPlugin.ts
+++ b/packages/carbon/src/plugins/redis-gateway-forwarder/ShardedRedisStreamGatewayForwarderPlugin.ts
@@ -1,0 +1,15 @@
+import {
+	ShardingPlugin,
+	type ShardingPluginOptions
+} from "../sharding/ShardingPlugin.js"
+import type { RedisStreamGatewayForwarderPluginOptions } from "./RedisStreamGatewayForwarderPlugin.js"
+import { RedisStreamGatewayForwarderPlugin } from "./RedisStreamGatewayForwarderPlugin.js"
+
+export type ShardedRedisStreamGatewayForwarderPluginOptions =
+	RedisStreamGatewayForwarderPluginOptions & ShardingPluginOptions
+
+export class ShardedRedisStreamGatewayForwarderPlugin extends ShardingPlugin {
+	override readonly id = "sharded-redis-gateway-forwarder" as "sharding"
+
+	customGatewayPlugin = RedisStreamGatewayForwarderPlugin
+}

--- a/packages/carbon/src/plugins/redis-gateway-forwarder/index.ts
+++ b/packages/carbon/src/plugins/redis-gateway-forwarder/index.ts
@@ -1,4 +1,4 @@
 export * from "./RedisStreamGatewayForwarderPlugin.js"
 export * from "./RedisStreamGatewayReceiverPlugin.js"
 export * from "./ShardedRedisStreamGatewayForwarderPlugin.js"
-export * from "./types.js"
+export type { RedisStreamClient } from "./types.js"

--- a/packages/carbon/src/plugins/redis-gateway-forwarder/index.ts
+++ b/packages/carbon/src/plugins/redis-gateway-forwarder/index.ts
@@ -1,0 +1,4 @@
+export * from "./RedisStreamGatewayForwarderPlugin.js"
+export * from "./RedisStreamGatewayReceiverPlugin.js"
+export * from "./ShardedRedisStreamGatewayForwarderPlugin.js"
+export * from "./types.js"

--- a/packages/carbon/src/plugins/redis-gateway-forwarder/types.ts
+++ b/packages/carbon/src/plugins/redis-gateway-forwarder/types.ts
@@ -1,65 +1,7 @@
-import type { Cluster, Redis, RedisValue } from "ioredis"
+import type { Cluster, Redis } from "ioredis"
 
 /**
  * Any ioredis client capable of running stream commands. Accepts a plain
  * `Redis` connection or a `Cluster` client interchangeably.
  */
 export type RedisStreamClient = Redis | Cluster
-
-/**
- * ioredis's stream command overloads are very variadic so both plugins bind through this
- * simpler signature instead.
- */
-export type VariadicRedisCommand = (...args: RedisValue[]) => Promise<unknown>
-
-/**
- * Derives the Redis Stream key for a client's gateway events.
- */
-export function deriveStreamKey(
-	clientId: string,
-	prefix = "carbon:events"
-): string {
-	return `${prefix}:${clientId}`
-}
-
-/** A single parsed entry read back off a stream. */
-export interface RedisStreamEntry {
-	id: string
-	type: string
-	data: unknown
-	/** `Date.now()` at the forwarder, captured when the gateway event was received (ms epoch). */
-	enqueuedAt: number | undefined
-}
-
-/**
- * Parses the flat field/value array ioredis returns for a stream entry
- * (as written by `RedisStreamGatewayForwarderPlugin`) into a typed shape.
- */
-export function parseStreamEntryFields(fields: string[]): {
-	type: string
-	data: unknown
-	enqueuedAt: number | undefined
-} {
-	let type = "unknown"
-	let data: unknown = null
-	let enqueuedAt: number | undefined
-	for (let i = 0; i < fields.length; i += 2) {
-		const field = fields[i]
-		const value = fields[i + 1]
-		if (field === "type" && typeof value === "string") {
-			type = value
-		}
-		if (field === "data" && typeof value === "string") {
-			try {
-				data = JSON.parse(value)
-			} catch {
-				data = null
-			}
-		}
-		if (field === "ts" && typeof value === "string") {
-			const parsed = Number(value)
-			if (Number.isFinite(parsed)) enqueuedAt = parsed
-		}
-	}
-	return { type, data, enqueuedAt }
-}

--- a/packages/carbon/src/plugins/redis-gateway-forwarder/types.ts
+++ b/packages/carbon/src/plugins/redis-gateway-forwarder/types.ts
@@ -1,0 +1,71 @@
+import type { Cluster, Redis, RedisValue } from "ioredis"
+
+/**
+ * Any ioredis client capable of running stream commands. Accepts a plain
+ * `Redis` connection or a `Cluster` client interchangeably.
+ */
+export type RedisStreamClient = Redis | Cluster
+
+/**
+ * ioredis's stream command overloads (`xadd`/`xgroup`/`xack`/`xautoclaim`/
+ * `xreadgroup`) are heavily variadic and tuple-typed per-overload, which
+ * fights back hard against argument lists built up at runtime. We only ever
+ * call these with flat argument lists, so both plugins bind through this
+ * simpler signature instead of wrestling the full overload set. `RedisValue`
+ * (`string | Buffer | number`) is ioredis's own exported type for a single
+ * command argument, so this stays honest about what ioredis actually accepts.
+ */
+export type VariadicRedisCommand = (...args: RedisValue[]) => Promise<unknown>
+
+/**
+ * Derives the Redis Stream key for a client's gateway events. Exported so the
+ * sender and receiver plugins can never disagree on the naming convention.
+ */
+export function deriveStreamKey(
+	clientId: string,
+	prefix = "carbon:events"
+): string {
+	return `${prefix}:${clientId}`
+}
+
+/** A single parsed entry read back off a stream. */
+export interface RedisStreamEntry {
+	id: string
+	type: string
+	data: unknown
+	/** `Date.now()` at the forwarder, captured when the gateway event was received (ms epoch). */
+	enqueuedAt: number | undefined
+}
+
+/**
+ * Parses the flat field/value array ioredis returns for a stream entry
+ * (as written by `RedisStreamGatewayForwarderPlugin`) into a typed shape.
+ */
+export function parseStreamEntryFields(fields: string[]): {
+	type: string
+	data: unknown
+	enqueuedAt: number | undefined
+} {
+	let type = "unknown"
+	let data: unknown = null
+	let enqueuedAt: number | undefined
+	for (let i = 0; i < fields.length; i += 2) {
+		const field = fields[i]
+		const value = fields[i + 1]
+		if (field === "type" && typeof value === "string") {
+			type = value
+		}
+		if (field === "data" && typeof value === "string") {
+			try {
+				data = JSON.parse(value)
+			} catch {
+				data = null
+			}
+		}
+		if (field === "ts" && typeof value === "string") {
+			const parsed = Number(value)
+			if (Number.isFinite(parsed)) enqueuedAt = parsed
+		}
+	}
+	return { type, data, enqueuedAt }
+}

--- a/packages/carbon/src/plugins/redis-gateway-forwarder/types.ts
+++ b/packages/carbon/src/plugins/redis-gateway-forwarder/types.ts
@@ -7,19 +7,13 @@ import type { Cluster, Redis, RedisValue } from "ioredis"
 export type RedisStreamClient = Redis | Cluster
 
 /**
- * ioredis's stream command overloads (`xadd`/`xgroup`/`xack`/`xautoclaim`/
- * `xreadgroup`) are heavily variadic and tuple-typed per-overload, which
- * fights back hard against argument lists built up at runtime. We only ever
- * call these with flat argument lists, so both plugins bind through this
- * simpler signature instead of wrestling the full overload set. `RedisValue`
- * (`string | Buffer | number`) is ioredis's own exported type for a single
- * command argument, so this stays honest about what ioredis actually accepts.
+ * ioredis's stream command overloads are very variadic so both plugins bind through this
+ * simpler signature instead.
  */
 export type VariadicRedisCommand = (...args: RedisValue[]) => Promise<unknown>
 
 /**
- * Derives the Redis Stream key for a client's gateway events. Exported so the
- * sender and receiver plugins can never disagree on the naming convention.
+ * Derives the Redis Stream key for a client's gateway events.
  */
 export function deriveStreamKey(
 	clientId: string,

--- a/packages/carbon/tests/plugins/redis-gateway-forwarder.test.ts
+++ b/packages/carbon/tests/plugins/redis-gateway-forwarder.test.ts
@@ -1,0 +1,583 @@
+import { EventEmitter } from "node:events"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import type { Client } from "../../src/classes/Client.js"
+import {
+	GatewayOpcodes,
+	type GatewayPayload
+} from "../../src/plugins/gateway/types.js"
+import { RedisStreamGatewayForwarderPlugin } from "../../src/plugins/redis-gateway-forwarder/RedisStreamGatewayForwarderPlugin.js"
+import { RedisStreamGatewayReceiverPlugin } from "../../src/plugins/redis-gateway-forwarder/RedisStreamGatewayReceiverPlugin.js"
+import { parseStreamEntryFields } from "../../src/plugins/redis-gateway-forwarder/types.js"
+
+class MockWebSocket extends EventEmitter {
+	readyState = 1
+	send = vi.fn()
+	close = vi.fn()
+}
+
+function createSenderPlugin(
+	redis: { xadd: ReturnType<typeof vi.fn> },
+	options: Partial<
+		ConstructorParameters<typeof RedisStreamGatewayForwarderPlugin>[0]
+	> = {}
+) {
+	const plugin = new RedisStreamGatewayForwarderPlugin({
+		intents: 1,
+		redis: redis as never,
+		...options
+	})
+	// Simulate `registerClient` having already derived the stream key.
+	;(plugin as unknown as { streamKey: string }).streamKey = "carbon:events:123"
+	const ws = new MockWebSocket()
+	;(plugin as unknown as { ws: MockWebSocket | null }).ws = ws
+	;(plugin as unknown as { setupWebSocket: () => void }).setupWebSocket()
+	return { ws, plugin }
+}
+
+function emitPayload(ws: MockWebSocket, payload: GatewayPayload) {
+	ws.emit("message", Buffer.from(JSON.stringify(payload)))
+}
+
+function getForwardedEvents(xadd: ReturnType<typeof vi.fn>) {
+	return xadd.mock.calls.map((call: unknown[]) => {
+		// call shape is [streamKey, ...maybeMaxlenTriple, id, "type", <type>, "data", <json>, "ts", <ts>]
+		const typeIndex = call.indexOf("type")
+		const fields = call.slice(typeIndex).map(String)
+		return parseStreamEntryFields(fields)
+	})
+}
+
+async function flushForwarding() {
+	await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe("RedisStreamGatewayForwarderPlugin guild availability forwarding", () => {
+	let xadd: ReturnType<typeof vi.fn>
+
+	beforeEach(() => {
+		xadd = vi.fn().mockResolvedValue("1-1")
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	test("forwards startup guild create as GUILD_AVAILABLE", async () => {
+		const { ws } = createSenderPlugin({ xadd })
+		emitPayload(ws, {
+			op: GatewayOpcodes.Dispatch,
+			t: "READY",
+			d: {
+				session_id: "session",
+				resume_gateway_url: "wss://gateway.discord.gg",
+				guilds: [{ id: "1" }]
+			}
+		})
+		const guildCreate = { id: "1", unavailable: false }
+		emitPayload(ws, {
+			op: GatewayOpcodes.Dispatch,
+			t: "GUILD_CREATE",
+			d: guildCreate
+		})
+
+		await flushForwarding()
+
+		const events = getForwardedEvents(xadd)
+		expect(events.map((event) => event.type)).toEqual([
+			"READY",
+			"GUILD_AVAILABLE"
+		])
+		expect(events[1]?.data).toEqual(guildCreate)
+	})
+
+	test("forwards true new guild join as GUILD_CREATE", async () => {
+		const { ws } = createSenderPlugin({ xadd })
+		const guildCreate = { id: "2", unavailable: false }
+		emitPayload(ws, {
+			op: GatewayOpcodes.Dispatch,
+			t: "GUILD_CREATE",
+			d: guildCreate
+		})
+
+		await flushForwarding()
+
+		const events = getForwardedEvents(xadd)
+		expect(events.map((event) => event.type)).toEqual(["GUILD_CREATE"])
+		expect(events[0]?.data).toEqual(guildCreate)
+	})
+
+	test("forwards unavailable guild delete as GUILD_UNAVAILABLE", async () => {
+		const { ws } = createSenderPlugin({ xadd })
+		const guildDelete = { id: "3", unavailable: true }
+		emitPayload(ws, {
+			op: GatewayOpcodes.Dispatch,
+			t: "GUILD_DELETE",
+			d: guildDelete
+		})
+
+		await flushForwarding()
+
+		const events = getForwardedEvents(xadd)
+		expect(events.map((event) => event.type)).toEqual(["GUILD_UNAVAILABLE"])
+		expect(events[0]?.data).toEqual(guildDelete)
+	})
+
+	test("retries transient xadd failures with bounded backoff", async () => {
+		xadd
+			.mockRejectedValueOnce(new Error("connection reset"))
+			.mockResolvedValueOnce("1-1")
+
+		const { ws, plugin } = createSenderPlugin(
+			{ xadd },
+			{
+				delivery: {
+					maxRetries: 2,
+					baseBackoffMs: 1,
+					maxBackoffMs: 1,
+					jitterRatio: 0,
+					timeoutMs: 50,
+					maxInFlight: 1
+				}
+			}
+		)
+
+		emitPayload(ws, {
+			op: GatewayOpcodes.Dispatch,
+			t: "GUILD_CREATE",
+			d: { id: "retry-guild", unavailable: false }
+		})
+
+		await new Promise((resolve) => setTimeout(resolve, 20))
+
+		expect(xadd).toHaveBeenCalledTimes(2)
+		const metrics = plugin.getDeliveryMetrics()
+		expect(metrics.retried).toBe(1)
+		expect(metrics.sent).toBe(1)
+		expect(metrics.failed).toBe(0)
+	})
+
+	test("respects maxInFlight by queueing excess deliveries", async () => {
+		const resolvers: Array<() => void> = []
+		xadd.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolvers.push(() => resolve("1-1"))
+				})
+		)
+
+		const { ws, plugin } = createSenderPlugin(
+			{ xadd },
+			{
+				delivery: {
+					maxInFlight: 1,
+					maxQueueSize: 10,
+					maxRetries: 0,
+					timeoutMs: 5000
+				}
+			}
+		)
+
+		emitPayload(ws, {
+			op: GatewayOpcodes.Dispatch,
+			t: "GUILD_CREATE",
+			d: { id: "A", unavailable: false }
+		})
+		emitPayload(ws, {
+			op: GatewayOpcodes.Dispatch,
+			t: "GUILD_CREATE",
+			d: { id: "B", unavailable: false }
+		})
+
+		await Promise.resolve()
+		expect(xadd).toHaveBeenCalledTimes(1)
+		expect(plugin.getDeliveryMetrics().queueDepth).toBe(1)
+
+		resolvers.shift()?.()
+		await Promise.resolve()
+		await Promise.resolve()
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		expect(xadd).toHaveBeenCalledTimes(2)
+		resolvers.shift()?.()
+		await Promise.resolve()
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		expect(plugin.getDeliveryMetrics().sent).toBe(2)
+	})
+
+	test("throws for invalid delivery maxInFlight", () => {
+		expect(() =>
+			createSenderPlugin(
+				{ xadd },
+				{
+					delivery: {
+						maxInFlight: 0
+					}
+				}
+			)
+		).toThrow("delivery.maxInFlight")
+	})
+})
+
+/**
+ * A minimal in-memory double for the subset of Redis Streams commands
+ * `RedisStreamGatewayReceiverPlugin` uses. Tracks per-(stream, group) delivery
+ * via an index cursor rather than real entry IDs, which keeps ordering
+ * comparisons trivial for test purposes.
+ */
+class FakeRedisStream {
+	private streams = new Map<string, string[][]>()
+	private groups = new Map<string, Map<string, { deliveredIndex: number }>>()
+	private pending = new Map<
+		string,
+		Map<string, Map<string, { consumer: string; fields: string[] }>>
+	>()
+	private idSeq = 0
+
+	private groupsFor(key: string) {
+		let groupsForStream = this.groups.get(key)
+		if (!groupsForStream) {
+			groupsForStream = new Map()
+			this.groups.set(key, groupsForStream)
+		}
+		return groupsForStream
+	}
+
+	private pendingFor(key: string, group: string) {
+		let pendingForStream = this.pending.get(key)
+		if (!pendingForStream) {
+			pendingForStream = new Map()
+			this.pending.set(key, pendingForStream)
+		}
+		let pendingForGroup = pendingForStream.get(group)
+		if (!pendingForGroup) {
+			pendingForGroup = new Map()
+			pendingForStream.set(group, pendingForGroup)
+		}
+		return pendingForGroup
+	}
+
+	async xadd(...args: unknown[]) {
+		const key = String(args[0])
+		const fields = args.slice(1).map(String)
+		this.idSeq += 1
+		const id = `${this.idSeq}-0`
+		const entries = this.streams.get(key) ?? []
+		entries.push([id, ...fields])
+		this.streams.set(key, entries)
+		return id
+	}
+
+	async xgroup(...args: unknown[]) {
+		const [sub, key, group] = args.map(String)
+		if (sub === "CREATE") {
+			const groupsForStream = this.groupsFor(key)
+			if (groupsForStream.has(group)) {
+				throw new Error("BUSYGROUP Consumer Group name already exists")
+			}
+			if (!this.streams.has(key)) this.streams.set(key, [])
+			groupsForStream.set(group, {
+				deliveredIndex: (this.streams.get(key) ?? []).length
+			})
+			return "OK"
+		}
+		return "OK"
+	}
+
+	async xreadgroup(...args: unknown[]) {
+		const a = args.map(String)
+		let i = 0
+		i++ // "GROUP"
+		const group = a[i++] ?? ""
+		const consumer = a[i++] ?? ""
+		let count = Number.POSITIVE_INFINITY
+		let blocked = false
+		while (i < a.length) {
+			if (a[i] === "COUNT") {
+				count = Number(a[i + 1])
+				i += 2
+				continue
+			}
+			if (a[i] === "BLOCK") {
+				blocked = true
+				i += 2
+				continue
+			}
+			if (a[i] === "STREAMS") {
+				i++
+				break
+			}
+			i++
+		}
+		const rest = a.slice(i)
+		const n = rest.length / 2
+		const keys = rest.slice(0, n)
+		const ids = rest.slice(n)
+
+		const collect = (): [string, [string, string[]][]][] => {
+			const result: [string, [string, string[]][]][] = []
+			for (let k = 0; k < keys.length; k++) {
+				const key = keys[k] ?? ""
+				const idArg = ids[k] ?? ""
+				const entries = this.streams.get(key) ?? []
+				const groupState = this.groupsFor(key).get(group)
+				if (!groupState) continue
+				const pendingForGroup = this.pendingFor(key, group)
+
+				let matched: [string, string[]][] = []
+				if (idArg === ">") {
+					const available = entries.slice(groupState.deliveredIndex)
+					const take = Number.isFinite(count) ? count : available.length
+					matched = available
+						.slice(0, take)
+						.map(([id, ...fields]) => [id, fields] as [string, string[]])
+					groupState.deliveredIndex += matched.length
+					for (const [id, fields] of matched) {
+						pendingForGroup.set(id, { consumer, fields })
+					}
+				} else {
+					matched = [...pendingForGroup.entries()]
+						.filter(([, p]) => p.consumer === consumer)
+						.map(([id, p]) => [id, p.fields] as [string, string[]])
+				}
+				if (matched.length > 0) result.push([key, matched])
+			}
+			return result
+		}
+
+		let result = collect()
+		if (result.length === 0 && blocked) {
+			await new Promise((resolve) => setTimeout(resolve, 5))
+			result = collect()
+		}
+		return result.length > 0 ? result : null
+	}
+
+	async xack(...args: unknown[]) {
+		const [key, group, ...ids] = args.map(String)
+		const pendingForGroup = this.pendingFor(key ?? "", group ?? "")
+		let acked = 0
+		for (const id of ids) {
+			if (pendingForGroup.delete(id)) acked += 1
+		}
+		return acked
+	}
+
+	async xautoclaim(...args: unknown[]) {
+		const [key, group, consumer] = args.map(String)
+		const pendingForGroup = this.pendingFor(key ?? "", group ?? "")
+		const claimed: [string, string[]][] = []
+		for (const [id, entry] of pendingForGroup) {
+			if (entry.consumer !== consumer) {
+				entry.consumer = consumer ?? ""
+				claimed.push([id, entry.fields])
+			}
+		}
+		return ["0-0", claimed]
+	}
+
+	pendingCount(key: string, group: string) {
+		return this.pendingFor(key, group).size
+	}
+}
+
+function fakeClient(clientId: string, handleEvent: ReturnType<typeof vi.fn>) {
+	return {
+		clientId,
+		eventHandler: { handleEvent }
+	} as unknown as Client
+}
+
+describe("RedisStreamGatewayReceiverPlugin", () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	test("registerClient creates the consumer group and swallows BUSYGROUP on re-registration", async () => {
+		const redis = new FakeRedisStream()
+		const receiver = new RedisStreamGatewayReceiverPlugin({
+			redis: redis as never,
+			blockingRedis: redis as never,
+			consumerGroup: "group",
+			consumerName: "consumer-1",
+			blockMs: 10
+		})
+
+		const client = fakeClient("123", vi.fn().mockReturnValue(true))
+		await receiver.registerClient(client)
+		await expect(receiver.registerClient(client)).resolves.toBeUndefined()
+
+		receiver.stop()
+	})
+
+	test("delivers entries from multiple streams to the right client", async () => {
+		const redis = new FakeRedisStream()
+		const onBackpressure = vi.fn()
+		const receiver = new RedisStreamGatewayReceiverPlugin({
+			redis: redis as never,
+			blockingRedis: redis as never,
+			consumerGroup: "group",
+			consumerName: "consumer-1",
+			blockMs: 10,
+			onBackpressure
+		})
+
+		const handleA = vi.fn().mockReturnValue(true)
+		const handleB = vi.fn().mockReturnValue(true)
+		const clientA = fakeClient("A", handleA)
+		const clientB = fakeClient("B", handleB)
+
+		await receiver.registerClient(clientA)
+		await receiver.registerClient(clientB)
+
+		await redis.xadd(
+			"carbon:events:A",
+			"type",
+			"MESSAGE_CREATE",
+			"data",
+			JSON.stringify({ id: "1" })
+		)
+		await redis.xadd(
+			"carbon:events:B",
+			"type",
+			"GUILD_CREATE",
+			"data",
+			JSON.stringify({ id: "2" })
+		)
+
+		await vi.waitFor(() => {
+			expect(handleA).toHaveBeenCalledTimes(1)
+			expect(handleB).toHaveBeenCalledTimes(1)
+		})
+
+		expect(handleA).toHaveBeenCalledWith(
+			{ id: "1", clientId: "A" },
+			"MESSAGE_CREATE"
+		)
+		expect(handleB).toHaveBeenCalledWith(
+			{ id: "2", clientId: "B" },
+			"GUILD_CREATE"
+		)
+		expect(onBackpressure).not.toHaveBeenCalled()
+
+		receiver.stop()
+	})
+
+	test("backpressure skips the ack and redelivers once capacity frees up", async () => {
+		const redis = new FakeRedisStream()
+		const onBackpressure = vi.fn()
+		const receiver = new RedisStreamGatewayReceiverPlugin({
+			redis: redis as never,
+			blockingRedis: redis as never,
+			consumerGroup: "group",
+			consumerName: "consumer-1",
+			blockMs: 10,
+			onBackpressure
+		})
+
+		let full = true
+		const handleEvent = vi.fn().mockImplementation(() => !full)
+		const client = fakeClient("A", handleEvent)
+		await receiver.registerClient(client)
+
+		await redis.xadd(
+			"carbon:events:A",
+			"type",
+			"MESSAGE_CREATE",
+			"data",
+			JSON.stringify({ id: "1" })
+		)
+
+		await vi.waitFor(() => {
+			expect(onBackpressure).toHaveBeenCalledWith("A")
+		})
+		expect(redis.pendingCount("carbon:events:A", "group")).toBe(1)
+
+		full = false
+
+		await vi.waitFor(() => {
+			expect(redis.pendingCount("carbon:events:A", "group")).toBe(0)
+		})
+		expect(handleEvent).toHaveBeenCalledWith(
+			{ id: "1", clientId: "A" },
+			"MESSAGE_CREATE"
+		)
+
+		receiver.stop()
+	})
+
+	test("detach stops future delivery without crashing the loop", async () => {
+		const redis = new FakeRedisStream()
+		const receiver = new RedisStreamGatewayReceiverPlugin({
+			redis: redis as never,
+			blockingRedis: redis as never,
+			consumerGroup: "group",
+			consumerName: "consumer-1",
+			blockMs: 10
+		})
+
+		const handleEvent = vi.fn().mockReturnValue(true)
+		const client = fakeClient("A", handleEvent)
+		await receiver.registerClient(client)
+		receiver.detach("A")
+
+		await redis.xadd(
+			"carbon:events:A",
+			"type",
+			"MESSAGE_CREATE",
+			"data",
+			JSON.stringify({ id: "1" })
+		)
+
+		await new Promise((resolve) => setTimeout(resolve, 30))
+		expect(handleEvent).not.toHaveBeenCalled()
+
+		receiver.stop()
+	})
+
+	test("XAUTOCLAIM sweep reclaims an entry left pending by a dead consumer", async () => {
+		const redis = new FakeRedisStream()
+		// Manually create the group and deliver an entry to a "dead" consumer,
+		// bypassing the plugin, to simulate a crash mid-processing.
+		await redis.xgroup("CREATE", "carbon:events:A", "group", "$")
+		await redis.xadd(
+			"carbon:events:A",
+			"type",
+			"MESSAGE_CREATE",
+			"data",
+			JSON.stringify({ id: "1" })
+		)
+		await redis.xreadgroup(
+			"GROUP",
+			"group",
+			"dead-consumer",
+			"STREAMS",
+			"carbon:events:A",
+			">"
+		)
+		expect(redis.pendingCount("carbon:events:A", "group")).toBe(1)
+
+		const receiver = new RedisStreamGatewayReceiverPlugin({
+			redis: redis as never,
+			blockingRedis: redis as never,
+			consumerGroup: "group",
+			consumerName: "consumer-1",
+			blockMs: 10,
+			autoclaimIntervalMs: 0
+		})
+
+		const handleEvent = vi.fn().mockReturnValue(true)
+		const client = fakeClient("A", handleEvent)
+		await receiver.registerClient(client)
+
+		await vi.waitFor(() => {
+			expect(handleEvent).toHaveBeenCalledWith(
+				{ id: "1", clientId: "A" },
+				"MESSAGE_CREATE"
+			)
+		})
+		expect(receiver.getMetrics().autoclaimReclaimed).toBeGreaterThanOrEqual(1)
+
+		receiver.stop()
+	})
+})

--- a/packages/carbon/tests/plugins/redis-gateway-forwarder.test.ts
+++ b/packages/carbon/tests/plugins/redis-gateway-forwarder.test.ts
@@ -7,7 +7,6 @@ import {
 } from "../../src/plugins/gateway/types.js"
 import { RedisStreamGatewayForwarderPlugin } from "../../src/plugins/redis-gateway-forwarder/RedisStreamGatewayForwarderPlugin.js"
 import { RedisStreamGatewayReceiverPlugin } from "../../src/plugins/redis-gateway-forwarder/RedisStreamGatewayReceiverPlugin.js"
-import { parseStreamEntryFields } from "../../src/plugins/redis-gateway-forwarder/types.js"
 
 class MockWebSocket extends EventEmitter {
 	readyState = 1
@@ -43,7 +42,28 @@ function getForwardedEvents(xadd: ReturnType<typeof vi.fn>) {
 		// call shape is [streamKey, ...maybeMaxlenTriple, id, "type", <type>, "data", <json>, "ts", <ts>]
 		const typeIndex = call.indexOf("type")
 		const fields = call.slice(typeIndex).map(String)
-		return parseStreamEntryFields(fields)
+		let type = "unknown"
+		let data: unknown = null
+		let enqueuedAt: number | undefined
+		for (let i = 0; i < fields.length; i += 2) {
+			const field = fields[i]
+			const value = fields[i + 1]
+			if (field === "type" && typeof value === "string") {
+				type = value
+			}
+			if (field === "data" && typeof value === "string") {
+				try {
+					data = JSON.parse(value)
+				} catch {
+					data = null
+				}
+			}
+			if (field === "ts" && typeof value === "string") {
+				const parsed = Number(value)
+				if (Number.isFinite(parsed)) enqueuedAt = parsed
+			}
+		}
+		return { type, data, enqueuedAt }
 	})
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,10 @@ importers:
       discord-api-types:
         specifier: 0.38.49
         version: 0.38.49
+    devDependencies:
+      ioredis:
+        specifier: ^5.6.1
+        version: 5.11.1
 
   packages/carbon-testing:
     dependencies:
@@ -753,6 +757,9 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@ioredis/commands@1.10.0':
+    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -1502,6 +1509,10 @@ packages:
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
 
+  cluster-key-slot@1.1.1:
+    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
+    engines: {node: '>=0.10.0'}
+
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
@@ -1572,6 +1583,10 @@ packages:
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -1919,6 +1934,10 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  ioredis@5.11.1:
+    resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
+    engines: {node: '>=12.22.0'}
 
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
@@ -2618,6 +2637,14 @@ packages:
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
@@ -2788,6 +2815,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -3685,6 +3715,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.0.0
 
+  '@ioredis/commands@1.10.0': {}
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -4410,6 +4442,8 @@ snapshots:
 
   chardet@2.2.0: {}
 
+  cluster-key-slot@1.1.1: {}
+
   collapse-white-space@2.1.0: {}
 
   comma-separated-tokens@2.0.3: {}
@@ -4464,6 +4498,8 @@ snapshots:
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
+
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -4951,6 +4987,18 @@ snapshots:
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
+
+  ioredis@5.11.1:
+    dependencies:
+      '@ioredis/commands': 1.10.0
+      cluster-key-slot: 1.1.1
+      debug: 4.4.3
+      denque: 2.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   ip-address@10.2.0: {}
 
@@ -5851,6 +5899,12 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
@@ -6162,6 +6216,8 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
 


### PR DESCRIPTION
- [x] Tested via a Kiai test instance that is ready to go.

New `@buape/carbon/redis-gateway-forwarder` module with `RedisStreamGatewayForwarderPlugin` / `ShardedRedisStreamGatewayForwarderPlugin` (sender) and `RedisStreamGatewayReceiverPlugin` (receiver). This is an alternative to `GatewayForwarderPlugin`'s HTTP webhook for forwarding gateway events. Delivers via one Redis Stream per client.

Delivery/registration errors are reported through `onDeliveryLatency`/`onDeliverError`/`onRegisterError`/`onBackpressure` callbacks (receiver) and the emitter`'s `"error"` event (sender).


