### PR TITLE
feat: add channel obfuscation support

### DIFF
--- a/.changeset/channel-obfuscation.md
+++ b/.changeset/channel-obfuscation.md
@@ -1,0 +1,5 @@
+---
+"@buape/carbon": patch
+---
+
+feat: add channel obfuscation support

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,8 @@ Listeners extend specific event listener classes:
 
 ## Important Implementation Notes
 
+- For Discord API types that are not yet available in `discord-api-types`, prefer existing overrides/module augmentations in `packages/carbon/src/types/index.ts` instead of creating separate type files; for enum flags, hardcode the value locally with a TODO until `discord-api-types` supports it.
+- Changeset summaries should use conventional commits format and match the commit title.
 - The framework auto-discovers and registers components used in responses
 - Plugin architecture allows extending functionality without modifying core
 - Multi-runtime support requires adapter-specific testing

--- a/packages/carbon/src/abstracts/BaseChannel.ts
+++ b/packages/carbon/src/abstracts/BaseChannel.ts
@@ -148,6 +148,21 @@ export abstract class BaseChannel<
 	}
 
 	/**
+	 * Whether this channel's metadata has been obfuscated because the current app
+	 * cannot view it.
+	 *
+	 * Obfuscated channels are sent over the Gateway with redacted metadata. Check
+	 * this before displaying channel metadata such as the name or topic.
+	 *
+	 * @see https://discord.com/developers/docs/resources/channel#channel-object-obfuscated-channels
+	 */
+	get obfuscated(): IfPartial<IsPartial, boolean> {
+		if (!this._rawData) return undefined as never
+		// TODO: Use ChannelFlags.Obfuscated once it is available in discord-api-types.
+		return Boolean((this._rawData.flags ?? 0) & (1 << 17)) as never
+	}
+
+	/**
 	 * Fetches the channel from the API.
 	 * @returns A Promise that resolves to a non-partial channel
 	 */


### PR DESCRIPTION
## Summary
- Expose `channel.obfuscated` on channel structures so bots can detect redacted gateway channel metadata
- Hardcode the upcoming `CHANNEL_OBFUSCATED` bit with a TODO until it lands in `discord-api-types`
- Add a changeset for the patch release

## Testing
- `pnpm --filter @buape/carbon build`
- `pnpm lint`


discord/discord-api-docs#8454