### PR TITLE
Replace Invidget domain

### DIFF
--- a/website/pages/beta/getting-started/introduction.mdx
+++ b/website/pages/beta/getting-started/introduction.mdx
@@ -12,8 +12,8 @@ Carbon is a powerful and versatile framework designed for building HTTP-based Di
 Join our community on [Discord](https://go.buape.com/carbon) to connect with fellow developers, share your projects, and get support. We look forward to seeing the innovative bots you create with Carbon!
 
 <div className="theme-light-only">
-[![Discord Invite](https://invidget.switchblade.xyz/rT8vZAmVaQ?theme=light)](https://go.buape.com/carbon)
+[![Discord Invite](https://inv.bua.pe/rT8vZAmVaQ?theme=light)](https://go.buape.com/carbon)
 </div>
 <div className="theme-dark-only">
-[![Discord Invite](https://invidget.switchblade.xyz/rT8vZAmVaQ?theme=dark)](https://go.buape.com/carbon)
+[![Discord Invite](https://inv.bua.pe/rT8vZAmVaQ?theme=dark)](https://go.buape.com/carbon)
 </div>

--- a/website/pages/v0.15.0/getting-started/introduction.mdx
+++ b/website/pages/v0.15.0/getting-started/introduction.mdx
@@ -12,8 +12,8 @@ Carbon is a powerful and versatile framework designed for building HTTP-based Di
 Join our community on [Discord](https://go.buape.com/carbon) to connect with fellow developers, share your projects, and get support. We look forward to seeing the innovative bots you create with Carbon!
 
 <div className="theme-light-only">
-[![Discord Invite](https://invidget.switchblade.xyz/rT8vZAmVaQ?theme=light)](https://go.buape.com/carbon)
+[![Discord Invite](https://inv.bua.pe/rT8vZAmVaQ?theme=light)](https://go.buape.com/carbon)
 </div>
 <div className="theme-dark-only">
-[![Discord Invite](https://invidget.switchblade.xyz/rT8vZAmVaQ?theme=dark)](https://go.buape.com/carbon)
+[![Discord Invite](https://inv.bua.pe/rT8vZAmVaQ?theme=dark)](https://go.buape.com/carbon)
 </div>

--- a/website/pages/v0.16.0/getting-started/introduction.mdx
+++ b/website/pages/v0.16.0/getting-started/introduction.mdx
@@ -12,8 +12,8 @@ Carbon is a powerful and versatile framework designed for building HTTP-based Di
 Join our community on [Discord](https://go.buape.com/carbon) to connect with fellow developers, share your projects, and get support. We look forward to seeing the innovative bots you create with Carbon!
 
 <div className="theme-light-only">
-[![Discord Invite](https://invidget.switchblade.xyz/rT8vZAmVaQ?theme=light)](https://go.buape.com/carbon)
+[![Discord Invite](https://inv.bua.pe/rT8vZAmVaQ?theme=light)](https://go.buape.com/carbon)
 </div>
 <div className="theme-dark-only">
-[![Discord Invite](https://invidget.switchblade.xyz/rT8vZAmVaQ?theme=dark)](https://go.buape.com/carbon)
+[![Discord Invite](https://inv.bua.pe/rT8vZAmVaQ?theme=dark)](https://go.buape.com/carbon)
 </div>


### PR DESCRIPTION
## Summary

- Replace `invidget.switchblade.xyz` invite widget URLs with `inv.bua.pe`.

## Testing

- Not run (docs/link-only change).

---
Triggered by @thewilloftheshadow: https://discord.com/channels/1080982186045493338/1081012395259998289/1540560658758893619
